### PR TITLE
New Path class that makes building/manipulating URLs easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 bundler_args: --without development
 rvm:
-  - 1.8.7
   - 1.9.2
   - 1.9.3
   - 2.0.0

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -26,6 +26,15 @@ Now call `sign_path` on your client to get a signed URL.
 
 ``` ruby
 client = Imgix::Client.new(:host => 'your-subdomain.imgix.net', :token => 'your-token', :secure => true)
+
+client.path('/images/demo.png').to_url({w: 200})
+
+# OR
+path = client.path('/images/demo.png')
+path.width = 200
+path.to_url
+
+# OR
 client.sign_path('/images/demo.png?w=200')
 #=> https://your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
 ```

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -38,6 +38,9 @@ path = client.path('/images/demo.png')
 path.width = 200
 path.to_url
 
+# OR
+client.path('/images/demo.png').width(200).height(300).to_url
+
 # Some other tricks
 path.defaults.width(300).to_url # Resets parameters
 path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -48,7 +48,7 @@ path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 
 ## Supported Ruby Versions
 
-Imgix is tested under 1.8.7, 1.9.2, 1.9.3, 2.0.0, JRuby 1.7.2 (1.9 mode), and Rubinius 2.0.0 (1.9 mode).
+Imgix is tested under 1.9.2, 1.9.3, 2.0.0, JRuby 1.7.2 (1.9 mode), and Rubinius 2.0.0 (1.9 mode).
 
 [![Build Status](https://travis-ci.org/soffes/imgix-rb.png?branch=master)](https://travis-ci.org/soffes/imgix-rb)
 

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -22,21 +22,25 @@ Or install it yourself as:
 
 Simply initialize a client with a host and your token. You can optionally generate secure URLs.
 
-Now call `sign_path` on your client to get a signed URL.
+Now, if you have the URL ready to go, you can call `sign_path` to get the Imgix URL back. If you would like to manipulate the path parameters you can call `path` with the resource path to get an Imgix::Path object back.
 
 ``` ruby
 client = Imgix::Client.new(:host => 'your-subdomain.imgix.net', :token => 'your-token', :secure => true)
 
-client.path('/images/demo.png').to_url({w: 200})
+client.sign_path('/images/demo.png?w=200')
+#=> https://your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
+
+# OR
+client.path('/images/demo.png').to_url(w: 200)
 
 # OR
 path = client.path('/images/demo.png')
 path.width = 200
 path.to_url
 
-# OR
-client.sign_path('/images/demo.png?w=200')
-#=> https://your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
+# Some other tricks
+path.defaults.width(300).to_url # Resets parameters
+path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 ```
 
 ## Supported Ruby Versions

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.9.0'
   spec.add_dependency 'addressable'
 end

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -6,8 +6,8 @@ require 'imgix/version'
 Gem::Specification.new do |spec|
   spec.name          = 'imgix'
   spec.version       = Imgix::VERSION
-  spec.authors       = ['Sam Soffes']
-  spec.email         = ['sam@soff.es']
+  spec.authors       = ['Sam Soffes', 'Ryan LeFevre']
+  spec.email         = ['sam@soff.es', 'ryan@layervault.com']
   spec.description   = 'Easily sign imgix URLs.'
   spec.summary       = 'Unofficial Ruby Gem for easily signing imgix URLs.'
   spec.homepage      = 'https://github.com/soffes/imgix-rb'

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -1,6 +1,6 @@
-require_relative 'imgix/version'
-require_relative 'imgix/client'
-require_relative 'imgix/path'
+require 'imgix/version'
+require 'imgix/client'
+require 'imgix/path'
 
 module Imgix
 end

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -1,5 +1,6 @@
-require 'imgix/version'
-require 'imgix/client'
+require_relative 'imgix/version'
+require_relative 'imgix/client'
+require_relative 'imgix/path'
 
 module Imgix
 end

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -6,7 +6,7 @@ module Imgix
     def initialize(options = {})
       @host = options[:host]
       @token = options[:token]
-      @secure = options[:secure]
+      @secure = options[:secure] || false
     end
 
     def path(path)

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -9,6 +9,14 @@ module Imgix
       @secure = options[:secure]
     end
 
+    def path(path)
+      Path.new(prefix, @token, path)
+    end
+
+    def prefix
+      "#{@secure ? 'https' : 'http'}://#{@host}"
+    end
+
     def sign_path(path)
       uri = Addressable::URI.parse(path)
       query = (uri.query || '')

--- a/lib/imgix/param_helpers.rb
+++ b/lib/imgix/param_helpers.rb
@@ -1,0 +1,16 @@
+module Imgix
+  module ParamHelpers
+    def rect(position)
+      @options[:rect] = position and return self if position.is_a?(String)
+
+      @options[:rect] = [
+        position[:x] || position[:left],
+        position[:y] || position[:top],
+        position[:width] || (position[:right] - position[:left]),
+        position[:height] || (position[:bottom] - position[:top])
+      ].join(',')
+
+      return self
+    end
+  end
+end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -31,12 +31,14 @@ module Imgix
       @token = token
       @path = path
       @options = {}
+
+      @path = "/#{@path}" if @path[0] != '/'
     end
 
     def to_url(opts={})
       @options.merge!(opts)
       
-      url = "#{@prefix}/#{path_and_params}"
+      url = @prefix + path_and_params
       url += (@options.length > 0 ? '&' : '') + "s=#{signature}"
 
       return url
@@ -77,7 +79,7 @@ module Imgix
     end
 
     def path_and_params
-      "#{@path}?#{query}".gsub(/^(\/)/, '')
+      "#{@path}?#{query}"
     end
 
     def query

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,5 +1,9 @@
+require 'imgix/param_helpers'
+
 module Imgix
   class Path
+    include ParamHelpers
+
     ALIASES = {
       width: :w,
       height: :h,
@@ -48,19 +52,21 @@ module Imgix
       if args.length == 0
         return @options[key]
       elsif args.first.nil? && @options.has_key?(key)
-        @options.delete(key) and return
+        @options.delete(key) and return self
       end
 
       @options[key] = args.join(',')
+      return self
     end
 
     ALIASES.each do |from, to|
-      define_method from do
-        @options[to]
+      define_method from do |*args|
+        self.send(to, *args)
       end
 
-      define_method "#{from}=" do |value|
-        @options[to] = value
+      define_method "#{from}=" do |*args|
+        self.send("#{to}=", *args)
+        return self
       end
     end
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -36,11 +36,13 @@ module Imgix
     end
 
     def to_url(opts={})
+      prev_options = @options.dup
       @options.merge!(opts)
       
       url = @prefix + path_and_params
       url += (@options.length > 0 ? '&' : '') + "s=#{signature}"
 
+      @options = prev_options
       return url
     end
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -3,7 +3,23 @@ module Imgix
     ALIASES = {
       width: :w,
       height: :h,
-      rotation: :rot
+      rotation: :rot,
+      noise_reduction: :nr,
+      sharpness: :sharp,
+      exposure: :exp,
+      vibrance: :vib,
+      saturation: :sat,
+      brightness: :bri,
+      contrast: :con,
+      highlight: :high,
+      shadow: :shad,
+      gamma: :gam,
+      pixelate: :px,
+      halftone: :htn,
+      watermark: :mark,
+      text: :txt,
+      format: :fm,
+      quality: :q
     }
 
     def initialize(prefix, token, path = '/')
@@ -35,7 +51,7 @@ module Imgix
         @options.delete(key) and return
       end
 
-      @options[key] = args.first
+      @options[key] = args.join(',')
     end
 
     ALIASES.each do |from, to|

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,0 +1,65 @@
+module Imgix
+  class Path
+    ALIASES = {
+      width: :w,
+      height: :h,
+      rotation: :rot
+    }
+
+    def initialize(prefix, token, path = '/')
+      @prefix = prefix
+      @token = token
+      @path = path
+      @options = {}
+    end
+
+    def to_url(opts={})
+      @options.merge!(opts)
+      
+      url = "#{@prefix}/#{path_and_params}"
+      url += (@options.length > 0 ? '&' : '') + "s=#{signature}"
+
+      return url
+    end
+
+    def defaults
+      @options = {}
+      return self
+    end
+
+    def method_missing(method, *args, &block)
+      key = method.to_s.gsub('=', '')
+      if args.length == 0
+        return @options[key]
+      elsif args.first.nil? && @options.has_key?(key)
+        @options.delete(key) and return
+      end
+
+      @options[key] = args.first
+    end
+
+    ALIASES.each do |from, to|
+      define_method from do
+        @options[to]
+      end
+
+      define_method "#{from}=" do |value|
+        @options[to] = value
+      end
+    end
+
+    private
+
+    def signature      
+      Digest::MD5.hexdigest(@token + @path + '?' + query)
+    end
+
+    def path_and_params
+      "#{@path}?#{query}".gsub(/^(\/)/, '')
+    end
+
+    def query
+      @options.map { |k, v| "#{k.to_s}=#{v}" }.join('&')
+    end
+  end
+end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -5,25 +5,25 @@ module Imgix
     include ParamHelpers
 
     ALIASES = {
-      :width =>           :w,
-      :height =>          :h,
-      :rotation =>        :rot,
-      :noise_reduction => :nr,
-      :sharpness =>       :sharp,
-      :exposure =>        :exp,
-      :vibrance =>        :vib,
-      :saturation =>      :sat,
-      :brightness =>      :bri,
-      :contrast =>        :con,
-      :highlight =>       :high,
-      :shadow =>          :shad,
-      :gamma =>           :gam,
-      :pixelate =>        :px,
-      :halftone =>        :htn,
-      :watermark =>       :mark,
-      :text =>            :txt,
-      :format =>          :fm,
-      :quality =>         :q
+      width:           :w,
+      height:          :h,
+      rotation:        :rot,
+      noise_reduction: :nr,
+      sharpness:       :sharp,
+      exposure:        :exp,
+      vibrance:        :vib,
+      saturation:      :sat,
+      brightness:      :bri,
+      contrast:        :con,
+      highlight:       :high,
+      shadow:          :shad,
+      gamma:           :gam,
+      pixelate:        :px,
+      halftone:        :htn,
+      watermark:       :mark,
+      text:            :txt,
+      format:          :fm,
+      quality:         :q
     }
 
     def initialize(prefix, token, path = '/')

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -5,25 +5,25 @@ module Imgix
     include ParamHelpers
 
     ALIASES = {
-      width: :w,
-      height: :h,
-      rotation: :rot,
-      noise_reduction: :nr,
-      sharpness: :sharp,
-      exposure: :exp,
-      vibrance: :vib,
-      saturation: :sat,
-      brightness: :bri,
-      contrast: :con,
-      highlight: :high,
-      shadow: :shad,
-      gamma: :gam,
-      pixelate: :px,
-      halftone: :htn,
-      watermark: :mark,
-      text: :txt,
-      format: :fm,
-      quality: :q
+      :width =>           :w,
+      :height =>          :h,
+      :rotation =>        :rot,
+      :noise_reduction => :nr,
+      :sharpness =>       :sharp,
+      :exposure =>        :exp,
+      :vibrance =>        :vib,
+      :saturation =>      :sat,
+      :brightness =>      :bri,
+      :contrast =>        :con,
+      :highlight =>       :high,
+      :shadow =>          :shad,
+      :gamma =>           :gam,
+      :pixelate =>        :px,
+      :halftone =>        :htn,
+      :watermark =>       :mark,
+      :text =>            :txt,
+      :format =>          :fm,
+      :quality =>         :q
     }
 
     def initialize(prefix, token, path = '/')

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class UrlTest < Imgix::Test
+  def test_creating_a_path
+    path = client.path('/images/demo.png')
+    assert_equal 'http://demo.imgix.net/images/demo.png?s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+
+    path = client.path('images/demo.png')
+    assert_equal 'http://demo.imgix.net/images/demo.png?s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+  end
+
+  def test_signing_path_with_param
+    url = 'http://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
+    path = client.path('/images/demo.png')
+    path.width = 200
+
+    assert_equal url, path.to_url
+
+    path = client.path('/images/demo.png')
+    assert_equal url, path.to_url(w: 200)
+
+    path = client.path('/images/demo.png')
+    assert_equal url, path.width(200).to_url
+  end
+
+  def test_resetting_defaults
+    url = 'http://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
+    path = client.path('/images/demo.png')
+    path.height = 300
+
+    assert_equal url, path.defaults.to_url(w: 200)
+  end
+
+  def test_path_with_multiple_params
+    url = 'http://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a'
+    path = client.path('/images/demo.png')
+
+    assert_equal url, path.to_url(h: 200, w: 200)
+
+    path = client.path('/images/demo.png')
+    assert_equal url, path.height(200).width(200).to_url
+  end
+
+private
+
+  def client
+    @client ||= Imgix::Client.new(:host => 'demo.imgix.net', :token => '10adc394')
+  end
+end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -17,7 +17,7 @@ class UrlTest < Imgix::Test
     assert_equal url, path.to_url
 
     path = client.path('/images/demo.png')
-    assert_equal url, path.to_url({:w => 200})
+    assert_equal url, path.to_url(w: 200)
 
     path = client.path('/images/demo.png')
     assert_equal url, path.width(200).to_url
@@ -28,14 +28,14 @@ class UrlTest < Imgix::Test
     path = client.path('/images/demo.png')
     path.height = 300
 
-    assert_equal url, path.defaults.to_url({:w => 200})
+    assert_equal url, path.defaults.to_url(w: 200)
   end
 
   def test_path_with_multiple_params
     url = 'http://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a'
     path = client.path('/images/demo.png')
 
-    assert_equal url, path.to_url({:h => 200, :w => 200})
+    assert_equal url, path.to_url(h: 200, w: 200)
 
     path = client.path('/images/demo.png')
     assert_equal url, path.height(200).width(200).to_url

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -17,7 +17,7 @@ class UrlTest < Imgix::Test
     assert_equal url, path.to_url
 
     path = client.path('/images/demo.png')
-    assert_equal url, path.to_url(w: 200)
+    assert_equal url, path.to_url({:w => 200})
 
     path = client.path('/images/demo.png')
     assert_equal url, path.width(200).to_url
@@ -28,14 +28,14 @@ class UrlTest < Imgix::Test
     path = client.path('/images/demo.png')
     path.height = 300
 
-    assert_equal url, path.defaults.to_url(w: 200)
+    assert_equal url, path.defaults.to_url({:w => 200})
   end
 
   def test_path_with_multiple_params
     url = 'http://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a'
     path = client.path('/images/demo.png')
 
-    assert_equal url, path.to_url(h: 200, w: 200)
+    assert_equal url, path.to_url({:h => 200, :w => 200})
 
     path = client.path('/images/demo.png')
     assert_equal url, path.height(200).width(200).to_url


### PR DESCRIPTION
I've added a new Path class that lets you work with the URL in a more resource-oriented manner by letting you build it with either methods or an options hash. Check out the updated README for some examples.

I've maintained backwards compatibility with the `sign_path` method so nothing will break in the transition. I've also added some new tests for the additions. Ruby 1.8 compatibility should be maintained if all goes well.
