### PR TITLE
Fix a bug due to imgix's bug

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -21,7 +21,7 @@ module Imgix
       uri = Addressable::URI.parse(path)
       query = (uri.query || '')
       signature = Digest::MD5.hexdigest(@token + uri.path + '?' + query)
-      "#{@secure ? 'https' : 'http'}://#{@host}#{uri.path}?#{query}#{query.length > 0 ? '&' : ''}s=#{signature}"
+      "#{@secure ? 'https' : 'http'}://#{@host}#{uri.path}?#{query}&s=#{signature}"
     end
   end
 end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -40,7 +40,11 @@ module Imgix
       @options.merge!(opts)
       
       url = @prefix + path_and_params
-      url += (@options.length > 0 ? '&' : '') + "s=#{signature}"
+
+      # Weird bug in imgix. If there are no params, you still have
+      # to put & in front of the signature or else you will get
+      # unauthorized.
+      url += "&s=#{signature}"
 
       @options = prev_options
       return url

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class UrlTest < Imgix::Test
   def test_creating_a_path
     path = client.path('/images/demo.png')
-    assert_equal 'http://demo.imgix.net/images/demo.png?s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+    assert_equal 'http://demo.imgix.net/images/demo.png?&s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
 
     path = client.path('images/demo.png')
-    assert_equal 'http://demo.imgix.net/images/demo.png?s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+    assert_equal 'http://demo.imgix.net/images/demo.png?&s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
   end
 
   def test_signing_path_with_param

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class UrlTest < Imgix::Test
   def test_signing_with_no_params
     path = '/images/demo.png'
-    assert_equal 'http://demo.imgix.net/images/demo.png?s=3c1d676d4daf28c044dd83e8548f834a', client.sign_path(path)
+    assert_equal 'http://demo.imgix.net/images/demo.png?&s=3c1d676d4daf28c044dd83e8548f834a', client.sign_path(path)
   end
 
   def test_signing_with_one


### PR DESCRIPTION
So this is pretty great... there's a bug with imgix where, if there are no params, an `&` is still required in front of the signature or else you will get Unauthorized. It doesn't even change the signature calculation, just the final URL.
