### PR TITLE
Encode uri components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .bundle
 .config
 .yardoc
+.ruby-version
 Gemfile.lock
 InstalledFiles
 _yardoc

--- a/Readme.markdown
+++ b/Readme.markdown
@@ -71,6 +71,8 @@ For example to use the [noise reduction](http://www.imgix.com/docs/urlapi/enhanc
 path.noise_reduction(50,50)
 ```
 
+# URL encoding and signed ImgIX URLs
+Some important third parties (like Facebook) apply URL escaping to query string components, which can cause correctly signed ImgIX URLs to to be transformed into incorrectly signed ones. We URL encode the query part of the URL before signing, so you don't have to worry about this.
 
 ## Supported Ruby Versions
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,3 +1,4 @@
+require 'cgi/util'
 require 'imgix/param_helpers'
 
 module Imgix
@@ -38,7 +39,7 @@ module Imgix
     def to_url(opts={})
       prev_options = @options.dup
       @options.merge!(opts)
-      
+
       url = @prefix + path_and_params
 
       # Weird bug in imgix. If there are no params, you still have
@@ -80,7 +81,7 @@ module Imgix
 
     private
 
-    def signature      
+    def signature
       Digest::MD5.hexdigest(@token + @path + '?' + query)
     end
 
@@ -89,7 +90,7 @@ module Imgix
     end
 
     def query
-      @options.map { |k, v| "#{k.to_s}=#{v}" }.join('&')
+      @options.map { |k, v| "#{k.to_s}=#{CGI.escape(v.to_s)}" }.join('&')
     end
   end
 end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -41,6 +41,13 @@ class PathTest < Imgix::Test
     assert_equal url, path.height(200).width(200).to_url
   end
 
+  def test_path_with_multi_value_param_safely_encoded
+    url = 'http://demo.imgix.net/images/demo.png?markalign=middle%2Ccenter&s=f0d0e28a739f022638f4ba6dddf9b694'
+    path = client.path('/images/demo.png')
+
+    assert_equal url, path.markalign('middle', 'center').to_url
+  end
+
   def test_host_is_required
     assert_raises(ArgumentError) {Imgix::Client.new}
   end


### PR DESCRIPTION
Facebook URL-encodes URLs it receives pretty strictly, which can break
ImgIX URL signing because it's based on the URL string, not parsed key /
value components. This change pre-emptively URL-encodes so that signed URLs
are more robust and can be used for, e.g. Facebook sharing & Open Graph og:image objects
