### PR TITLE
Make tokens optional

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -4,7 +4,7 @@ require 'zlib'
 
 module Imgix
   class Client
-    DEFAULTS = { secure: false, shard_strategy: :crc }
+    DEFAULTS = { secure: false, shard_strategy: :crc, token: "" }
 
     def initialize(options = {})
       options = DEFAULTS.merge(options)

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -4,7 +4,7 @@ require 'zlib'
 
 module Imgix
   class Client
-    DEFAULTS = { secure: false, shard_strategy: :crc, token: "" }
+    DEFAULTS = { secure: false, shard_strategy: :crc }
 
     def initialize(options = {})
       options = DEFAULTS.merge(options)
@@ -26,8 +26,12 @@ module Imgix
     def sign_path(path)
       uri = Addressable::URI.parse(path)
       query = (uri.query || '')
-      signature = Digest::MD5.hexdigest(@token + uri.path + '?' + query)
-      "#{@secure ? 'https' : 'http'}://#{get_host(path)}#{uri.path}?#{query}&s=#{signature}"
+      path = "#{@secure ? 'https' : 'http'}://#{get_host(path)}#{uri.path}?#{query}"
+      if @token
+        signature = Digest::MD5.hexdigest(@token + uri.path + '?' + query)
+        path += "&s=#{signature}"
+      end
+      return path
     end
 
     def get_host(path)

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -42,10 +42,12 @@ module Imgix
 
       url = @prefix + path_and_params
 
-      # Weird bug in imgix. If there are no params, you still have
-      # to put & in front of the signature or else you will get
-      # unauthorized.
-      url += "&s=#{signature}"
+      if @token
+        # Weird bug in imgix. If there are no params, you still have
+        # to put & in front of the signature or else you will get
+        # unauthorized.
+        url += "&s=#{signature}"
+      end
 
       @options = prev_options
       return url

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -54,7 +54,7 @@ class PathTest < Imgix::Test
 
   def test_token_is_optional
     client = Imgix::Client.new(host: 'demo.imgix.net')
-    url = 'http://demo.imgix.net/images/demo.png?&s=2b08a385422bb922463b46a5f65b9944'
+    url = 'http://demo.imgix.net/images/demo.png?'
     path = client.path('/images/demo.png')
 
     assert_equal url, path.to_url

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -52,6 +52,14 @@ class PathTest < Imgix::Test
     assert_raises(ArgumentError) {Imgix::Client.new}
   end
 
+  def test_token_is_optional
+    client = Imgix::Client.new(host: 'demo.imgix.net')
+    url = 'http://demo.imgix.net/images/demo.png?&s=2b08a385422bb922463b46a5f65b9944'
+    path = client.path('/images/demo.png')
+
+    assert_equal url, path.to_url
+  end
+
   private
 
   def client


### PR DESCRIPTION
The docs imply that it's valid to omit a token if you don't need signed paths, but the path signature methods assume `@token` is always a string and fail with `'NoMethodError: undefined method '+' for nil:NilClass'`.

This patch just skips appending signatures when the token is missing.