### PR TITLE
Add a relative schema option

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -50,6 +50,14 @@ path.defaults.width(300).to_url # Resets parameters
 path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 ```
 
+It's also possible to create schema-relative URLs for mixed-protocol sites. Note that passing `:secure => true` will override `relative`.
+
+```ruby
+relative = Imgix::Client.new(host: 'your-subdomain.imgix.net', relative: true)
+
+relative.sign_path('/images/demo.png?w=200')
+#=> //your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
+```
 
 ## Domain Sharded URLs
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -48,6 +48,20 @@ class PathTest < Imgix::Test
     assert_equal url, path.markalign('middle', 'center').to_url
   end
 
+  def test_relative_schema
+    client = Imgix::Client.new(host: 'demo.imgix.net', token: '10adc394', relative: true)
+    path = client.path('/images/demo.png')
+
+    assert_equal '//demo.imgix.net/images/demo.png?&s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+  end
+
+  def test_secure_trumps_relative_schema
+    client = Imgix::Client.new(host: 'demo.imgix.net', token: '10adc394', relative: true, secure: true)
+    path = client.path('/images/demo.png')
+
+    assert_equal 'https://demo.imgix.net/images/demo.png?&s=3c1d676d4daf28c044dd83e8548f834a', path.to_url
+  end
+
   def test_host_is_required
     assert_raises(ArgumentError) {Imgix::Client.new}
   end


### PR DESCRIPTION
Another patch for your consideration. Relative schemas mean we don't have to pay for HTTPS overhead when our site is accessed via HTTP, and won't generate mixed content warnings when accessed via HTTPS.

I don't love adding a new key to the config, but making `secure` take three options seemed wrong and folding all variants (default, secure, relative) into a new `protocol` option would break backwards compatibility.