### PR TITLE
Library incorrectly removes the hostname and protocol from Web Proxy paths

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,11 @@ Rake::TestTask.new(:test) do |t|
   t.pattern = 'test/**/*_test.rb'
 end
 task :default => :test
+
+task :console do
+  require 'irb'
+  require 'irb/completion'
+  require 'imgix'
+  ARGV.clear
+  IRB.start
+end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -33,6 +33,7 @@ module Imgix
       @path = path
       @options = {}
 
+      @path = CGI.escape(@path) if /^https?/ =~ @path
       @path = "/#{@path}" if @path[0] != '/'
     end
 

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -37,7 +37,6 @@ class DomainsTest < Imgix::Test
 
     path = client.path('/bridge.png')
     assert_equal 'http://demos-1.imgix.net/bridge.png?&s=13e68f249172e5f790344e85e7cdb14b', path.to_url
-
   end
 
   def test_strips_out_protocol
@@ -47,7 +46,18 @@ class DomainsTest < Imgix::Test
 
     path = client.path('/bridge.png')
     assert_equal 'http://demos-1.imgix.net/bridge.png?&s=13e68f249172e5f790344e85e7cdb14b', path.to_url
-
   end
 
+  def test_with_full_paths
+    client = Imgix::Client.new(:hosts => [
+        "demos-1.imgix.net",
+        "demos-2.imgix.net",
+        "demos-3.imgix.net",
+      ],
+      :token => '10adc394',
+      :shard_strategy => :cycle)
+
+    path = 'https://google.com/cats.gif'
+    assert_equal "http://demos-1.imgix.net/#{CGI.escape(path)}?&s=4c3ff935011f0d2251800e6a2bb68ee5", client.path(path).to_url
+  end
 end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -60,7 +60,18 @@ class PathTest < Imgix::Test
     assert_equal url, path.to_url
   end
 
-  private
+  def test_full_url
+    path = 'https://google.com/cats.gif'
+
+    assert_equal "http://demo.imgix.net/#{CGI.escape(path)}?&s=4c3ff935011f0d2251800e6a2bb68ee5", client.path(path).to_url
+  end
+
+  def test_full_url_with_a_space
+    path = 'https://my-demo-site.com/files/133467012/avatar icon.png'
+    assert_equal "http://demo.imgix.net/#{CGI.escape(path)}?&s=8943817bed50811f6ceedd8f4b84169d", client.path(path).to_url
+  end
+
+private
 
   def client
     @client ||= Imgix::Client.new(:host => 'demo.imgix.net', :token => '10adc394')


### PR DESCRIPTION
Given an example Web Proxy source: my-web-proxy.imgix.net

This Ruby library incorrectly removes the protocol and hostname from full URL "paths" given to the library, e.g. 

``` ruby
client = Imgix::Client.new(host: 'my-web-proxy.imgix.net', token: 'your-token', secure: true)
client.sign_path("https://some-other-image-site.com/cats.png")
 #=> "https://my-web-proxy.imgix.net/cats.png?&s=abc123"
```

Instead, the URL should maintain the full URL of the input image:

```
https://my-web-proxy.imgix.net/https://some-other-image-site.com/cats.png?&s=abc123
```
