### PR TITLE
Bugfix params with spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+/vendor/bundle

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -1,5 +1,4 @@
 require 'digest'
-require 'addressable/uri'
 require 'zlib'
 
 module Imgix

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,4 +1,5 @@
 require 'cgi/util'
+require 'addressable/uri'
 require 'imgix/param_helpers'
 
 module Imgix
@@ -90,7 +91,7 @@ module Imgix
     end
 
     def query
-      @options.map { |k, v| "#{k.to_s}=#{CGI.escape(v.to_s)}" }.join('&')
+      @options.map { |k, v| "#{k.to_s}=#{CGI.escape(v.to_s).gsub('+', '%20')}" }.join('&')
     end
 
     def has_query?

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,5 +1,4 @@
 require 'cgi/util'
-require 'addressable/uri'
 require 'imgix/param_helpers'
 
 module Imgix

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -48,6 +48,13 @@ class PathTest < Imgix::Test
     assert_equal url, path.markalign('middle', 'center').to_url
   end
 
+  def test_path_params_with_spaces
+    url = 'https://demo.imgix.net/images/demo.png?txt=Hello%20World&s=c4d702123e15b88495be582c133cc9ed'
+    path = client.path('/images/demo.png')
+
+    assert_equal url, path.to_url(txt: 'Hello World')
+  end
+
   def test_host_is_required
     assert_raises(ArgumentError) {Imgix::Client.new}
   end


### PR DESCRIPTION
Hi,

``` ruby
CGI.escape('Hello World') # "Hello+World"
```

This breaks when we're working with the txt param, outputting `Hello+World` instead of `Hello World`.
We can use `Addressable::URI.escape` to standardize escaping or just go the easier way (see below).

``` ruby
CGI.escape('Hello World').gsub('+', '%20') # "Hello World"
```

I've tried with [Addressable](https://github.com/sporkmonger/addressable) first, but it broke the specs and didn't had much time to rewrite parts of the code.
