### PR TITLE
Normalize trailing `/` in user supplied host option

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -31,7 +31,7 @@ module Imgix
     def get_host(path)
       host = host_for_crc(path) if @shard_strategy == :crc
       host = host_for_cycle if @shard_strategy == :cycle
-      host.gsub("http://","").gsub("https://","")
+      host.gsub("http://","").gsub("https://","").chomp("/")
     end
 
     def host_for_crc(path)

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -50,6 +50,15 @@ class DomainsTest < Imgix::Test
     assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
   end
 
+  def test_strips_out_trailing_slash
+    client = Imgix::Client.new(host: "http://demos-1.imgix.net/",
+      secure_url_token: '10adc394',
+      include_library_param: false)
+
+    path = client.path('/bridge.png')
+    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+  end
+
   def test_with_full_paths
     client = Imgix::Client.new(hosts: [
         "demos-1.imgix.net",


### PR DESCRIPTION
Currently if the `host` or `hosts` options contain a value with a trailing `/` the generated path URL has a double slash.

```
client = Imgix::Client.new({ host: 'https://imgix.net/' })
client.path('foo.jpg') # => ""https://imgix.net//foo.jpg"
```
