### PR TITLE
Escape all passed params + values, and handle b64.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ bundler_args: --without development
 before_install:
   - gem install bundler
   - rvm get head
-  - rvm use jruby-9.0.5.0 --install
 rvm:
   - 2.3.0
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
 bundler_args: --without development
-before_install: gem install bundler
+before_install:
+  - gem install bundler
+  - rvm get head
+  - rvm use jruby-9.0.5.0 --install
 rvm:
   - 2.3.0
-  - 2.2.2
-  - 1.9.2
-  - jruby-1.7.23
+  - 2.2.4
+  - 2.1.8
+  - jruby-9.0.5.0
   - rbx-2.11

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,3 +1,4 @@
+require 'base64'
 require 'cgi/util'
 require 'imgix/param_helpers'
 
@@ -90,7 +91,16 @@ module Imgix
     end
 
     def query
-      @options.map { |k, v| "#{k.to_s}=#{CGI.escape(v.to_s)}" }.join('&')
+      @options.map do |key, val|
+        escaped_key = CGI.escape(key.to_s)
+
+        if escaped_key.end_with? '64'
+          base64_encoded_val = Base64.urlsafe_encode64(val.to_s).delete('=')
+          "#{escaped_key}=#{base64_encoded_val}"
+        else
+          "#{escaped_key}=#{CGI.escape(val.to_s)}"
+        end
+      end.join('&')
     end
 
     def has_query?

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 
 class DomainsTest < Imgix::Test
-
   def test_deterministically_choosing_a_path
     client = Imgix::Client.new(hosts: [
         "demos-1.imgix.net",


### PR DESCRIPTION
This will also fix the vulnerability described in imgix/imgix-rails#21 once imgix-rails is updated to use this version of imgix-rb
