### PR TITLE
Use `ERB::Util.url_encode` for escaping params.

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'cgi/util'
+require 'erb'
 require 'imgix/param_helpers'
 
 module Imgix
@@ -92,13 +93,13 @@ module Imgix
 
     def query
       @options.map do |key, val|
-        escaped_key = CGI.escape(key.to_s)
+        escaped_key = ERB::Util.url_encode(key.to_s)
 
         if escaped_key.end_with? '64'
           base64_encoded_val = Base64.urlsafe_encode64(val.to_s).delete('=')
           "#{escaped_key}=#{base64_encoded_val}"
         else
-          "#{escaped_key}=#{CGI.escape(val.to_s)}"
+          "#{escaped_key}=#{ERB::Util.url_encode(val.to_s)}"
         end
       end.join('&')
     end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -53,15 +53,15 @@ class PathTest < Imgix::Test
       :'hello world' => 'interesting'
     })
 
-    assert_equal "https://demo.imgix.net/demo.png?hello+world=interesting", ix_url
+    assert_equal "https://demo.imgix.net/demo.png?hello%20world=interesting", ix_url
   end
 
   def test_param_values_are_escaped
     ix_url = unsigned_client.path('demo.png').to_url({
-      hello_world: '/foo"><script>alert("hacked")</script><'
+      hello_world: '/foo"> <script>alert("hacked")</script><'
     })
 
-    assert_equal "https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C", ix_url
+    assert_equal "https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C", ix_url
   end
 
   def test_base64_param_variants_are_base64_encoded
@@ -125,6 +125,6 @@ private
   end
 
   def unsigned_client
-    @client ||= Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
+    @unsigned_client ||= Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
   end
 end


### PR DESCRIPTION
This fixes the same core issue as described in #20, but without doing manual string replacement.
