### PR TITLE
Minor refactoring

### DIFF
--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.0'
+  spec.required_ruby_version = '>= 2.1.0'
   spec.add_dependency 'addressable'
 end

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -41,7 +41,7 @@ module Imgix
     end
 
     def host_for_cycle
-      @hosts_cycle = @hosts.cycle unless @hosts_cycle
+      @hosts_cycle ||= @hosts.cycle
       @hosts_cycle.next
     end
 

--- a/test/imgix/client_test.rb
+++ b/test/imgix/client_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+describe Imgix::Client do
+  describe '#host_for_cycle' do
+    let(:client) { Imgix::Client.new(hosts: ['host1', 'host2']) }
+
+    it 'returns host value in calling cycle' do
+      client.host_for_cycle.must_equal "host1"
+      client.host_for_cycle.must_equal "host2"
+      client.host_for_cycle.must_equal "host1"
+    end
+  end
+end


### PR DESCRIPTION
Few minor refactoring while I was checking out the code today at work:
* Use ||= instead of doing condition check for variable is set or not - It is more Ruby idiom to use `||=` to self assign if value is not yet set
* Update gemspec with support for only ruby 2.1.0 or newer