### PR TITLE
Replace CGI.escape with better spec conforming Addressable methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.1] - Apr 28, 2017
+
+* Replace CGI.escape with better spec conforming Addressable methods.
+* Make url path segment tests less self-fulfilling.
+
 ## [1.1.0] - February 24, 2016
 
 * Added automatic Base64 encoding for all Base64 variant parameters.

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -6,8 +6,8 @@ require 'imgix/version'
 Gem::Specification.new do |spec|
   spec.name          = 'imgix'
   spec.version       = Imgix::VERSION
-  spec.authors       = ['Kelly Sutton', 'Sam Soffes', 'Ryan LeFevre', 'Antony Denyer', 'Paul Straw']
-  spec.email         = ['kelly@imgix.com', 'sam@soff.es', 'ryan@layervault.com', 'email@antonydenyer.co.uk', 'paul@imgix.com']
+  spec.authors       = ['Kelly Sutton', 'Sam Soffes', 'Ryan LeFevre', 'Antony Denyer', 'Paul Straw', 'Mario Rosa']
+  spec.email         = ['kelly@imgix.com', 'sam@soff.es', 'ryan@layervault.com', 'email@antonydenyer.co.uk', 'paul@imgix.com', 'mario@dwaiter.com']
   spec.description   = 'Easily create and sign imgix URLs.'
   spec.summary       = 'Official Ruby Gem for easily creating and signing imgix URLs.'
   spec.homepage      = 'https://github.com/imgix/imgix-rb'

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -41,7 +41,7 @@ module Imgix
     end
 
     def host_for_cycle
-      @hosts_cycle = @hosts.cycle unless @hosts_cycle
+      @hosts_cycle ||= @hosts.cycle
       @hosts_cycle.next
     end
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,5 +1,5 @@
+require 'addressable/template'
 require 'base64'
-require 'cgi/util'
 require 'erb'
 require 'imgix/param_helpers'
 
@@ -35,7 +35,9 @@ module Imgix
       @path = path
       @options = {}
 
-      @path = CGI.escape(@path) if /^https?/ =~ @path
+      if /^https?/ =~ @path
+        @path = Addressable::Template.new("/{segment}").expand({"segment" => @path}).to_s
+      end
       @path = "/#{@path}" if @path[0] != '/'
     end
 

--- a/lib/imgix/version.rb
+++ b/lib/imgix/version.rb
@@ -1,3 +1,3 @@
 module Imgix
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -68,7 +68,8 @@ class DomainsTest < Imgix::Test
       shard_strategy: :cycle,
       include_library_param: false)
 
-    path = 'https://google.com/cats.gif'
-    assert_equal "https://demos-1.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
+    path = 'https://www.example.com/image.png'
+    path_escaped = 'https%3A%2F%2Fwww.example.com%2Fimage.png'
+    assert_equal "https://demos-1.imgix.net/#{path_escaped}?s=537aa674cbda9339e2b296705733119d", client.path(path).to_url
   end
 end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -93,14 +93,24 @@ class PathTest < Imgix::Test
   end
 
   def test_full_url
-    path = 'https://google.com/cats.gif'
+    path = 'https://www.example.com/image.png'
+    path_escaped = 'https%3A%2F%2Fwww.example.com%2Fimage.png'
 
-    assert_equal "https://demo.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
+    assert_equal "https://demo.imgix.net/#{path_escaped}?s=537aa674cbda9339e2b296705733119d", client.path(path).to_url
   end
 
   def test_full_url_with_a_space
-    path = 'https://my-demo-site.com/files/133467012/avatar icon.png'
-    assert_equal "https://demo.imgix.net/#{CGI.escape(path)}?s=35ca40e2e7b6bd208be2c4f7073f658e", client.path(path).to_url
+    path = 'https://www.example.com/an image.png'
+    path_escaped = 'https%3A%2F%2Fwww.example.com%2Fan%20image.png'
+
+    assert_equal "https://demo.imgix.net/#{path_escaped}?s=fc819de217963996b0ab75940bf9b8aa", client.path(path).to_url
+  end
+
+  def test_full_url_with_a_tilde
+    path = 'https://www.example.com/an~image.png'
+    path_escaped = 'https%3A%2F%2Fwww.example.com%2Fan~image.png'
+
+    assert_equal "https://demo.imgix.net/#{path_escaped}?s=3070bb156fedce7d5668746f0aff7edf", client.path(path).to_url
   end
 
   def test_include_library_param


### PR DESCRIPTION
Make url path segment tests less self-fulfilling.