### PR TITLE
Add failed case for path that has spaces

### DIFF
--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -2,6 +2,9 @@ require 'test_helper'
 
 class UrlTest < Imgix::Test
   DEMO_IMAGE_PATH = '/images/demo.png'
+  DEMO_IMAGE_WITH_SPACE_PATH = '/images/demo with space.png'
+  DEMO_URL_PATH = 'https://google.com/images/demo.png'
+  DEMO_URL_WITh_SPACE_PATH = 'https://google.com/images/demo file.png'
 
   def test_signing_with_no_params
     path = client.path(DEMO_IMAGE_PATH)
@@ -26,6 +29,27 @@ class UrlTest < Imgix::Test
     path.width = 200
     path.height = 200
     assert_equal 'https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379', path.to_url
+  end
+
+  def test_signing_with_full_url
+    path = client.path(DEMO_URL_PATH)
+    path.height = 200
+    path.width = 200
+    assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo.png?h=200&w=200&s=77421a9daeab4d762e97d1c7e4601330', path.to_url
+  end
+
+  def test_signing_with_unescaped_full_url_with_spaces
+    path = client.path(DEMO_URL_WITh_SPACE_PATH)
+    path.height = 200
+    path.width = 200
+    assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo+file.png?h=200&w=200&s=12a58ca5a6a54d89bcded0af1e32d398', path.to_url
+  end
+
+  def test_signing_with_image_path_with_spaces
+    path = client.path(DEMO_IMAGE_WITH_SPACE_PATH)
+    path.height = 200
+    path.width = 200
+    assert_equal 'https://demo.imgix.net/images/demo%20with%20space.png?h=200&w=200&s=c53532784a06e469321ae38cdd3b33be', path.to_url
   end
 
 private

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class UrlTest < Imgix::Test
   DEMO_IMAGE_PATH = '/images/demo.png'
   DEMO_IMAGE_WITH_SPACE_PATH = '/images/demo with space.png'
-  DEMO_URL_PATH = 'https://google.com/images/demo.png'
 
   def test_signing_with_no_params
     path = client.path(DEMO_IMAGE_PATH)
@@ -28,13 +27,6 @@ class UrlTest < Imgix::Test
     path.width = 200
     path.height = 200
     assert_equal 'https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379', path.to_url
-  end
-
-  def test_signing_with_full_url
-    path = client.path(DEMO_URL_PATH)
-    path.height = 200
-    path.width = 200
-    assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo.png?h=200&w=200&s=77421a9daeab4d762e97d1c7e4601330', path.to_url
   end
 
   def test_signing_with_image_path_with_spaces

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -4,7 +4,6 @@ class UrlTest < Imgix::Test
   DEMO_IMAGE_PATH = '/images/demo.png'
   DEMO_IMAGE_WITH_SPACE_PATH = '/images/demo with space.png'
   DEMO_URL_PATH = 'https://google.com/images/demo.png'
-  DEMO_URL_WITh_SPACE_PATH = 'https://google.com/images/demo file.png'
 
   def test_signing_with_no_params
     path = client.path(DEMO_IMAGE_PATH)
@@ -36,13 +35,6 @@ class UrlTest < Imgix::Test
     path.height = 200
     path.width = 200
     assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo.png?h=200&w=200&s=77421a9daeab4d762e97d1c7e4601330', path.to_url
-  end
-
-  def test_signing_with_unescaped_full_url_with_spaces
-    path = client.path(DEMO_URL_WITh_SPACE_PATH)
-    path.height = 200
-    path.width = 200
-    assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo+file.png?h=200&w=200&s=12a58ca5a6a54d89bcded0af1e32d398', path.to_url
   end
 
   def test_signing_with_image_path_with_spaces


### PR DESCRIPTION
For the S3 sources with path the contains space characters, the `to_url()` does not escape the path