### PR TITLE
Add a failed test case for wrong URI escaping

### DIFF
--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -2,6 +2,14 @@ require 'test_helper'
 
 class UrlTest < Imgix::Test
   DEMO_IMAGE_PATH = '/images/demo.png'
+  DEMO_URL_WITH_SPACE_PATH = 'https://google.com/images/demo file.png'
+
+  def test_signing_with_unescaped_full_url_with_spaces
+    path = client.path(DEMO_URL_WITH_SPACE_PATH)
+    path.height = 200
+    path.width = 200
+    assert_equal 'https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo%20file.png?h=200&w=200&s=12a58ca5a6a54d89bcded0af1e32d398', path.to_url
+  end
 
   def test_signing_with_no_params
     path = client.path(DEMO_IMAGE_PATH)


### PR DESCRIPTION
```
15:39 $ bundle exec ruby -Itest test/units/url_test.rb
Run options: --seed 12635

# Running:

..F.

Finished in 0.012004s, 333.2223 runs/s, 416.5278 assertions/s.

  1) Failure:
UrlTest#test_signing_with_unescaped_full_url_with_spaces [test/units/url_test.rb:11]:
--- expected
+++ actual
@@ -1 +1 @@
-"https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo%20file.png?h=200&w=200&s=12a58ca5a6a54d89bcded0af1e32d398"
+"https://demo.imgix.net/https%3A%2F%2Fgoogle.com%2Fimages%2Fdemo+file.png?h=200&w=200&s=12a58ca5a6a54d89bcded0af1e32d398"
```

The empty space should not be encoded as `+` because it is not part of the query, thus it should be encoded as `%20`