### PR TITLE
Improve memory usage

### DIFF
--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'imgix/version'
 require 'imgix/client'
 require 'imgix/path'

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest'
 require 'addressable/uri'
 require 'zlib'

--- a/lib/imgix/param_helpers.rb
+++ b/lib/imgix/param_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Imgix
   module ParamHelpers
     def rect(position)

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'cgi/util'
 require 'erb'

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -98,10 +98,9 @@ module Imgix
         escaped_key = ERB::Util.url_encode(key.to_s)
 
         if escaped_key.end_with? '64'
-          base64_encoded_val = Base64.urlsafe_encode64(val.to_s).delete('=')
-          "#{escaped_key}=#{base64_encoded_val}"
+          escaped_key << "=" << Base64.urlsafe_encode64(val.to_s).delete('=')
         else
-          "#{escaped_key}=#{ERB::Util.url_encode(val.to_s)}"
+          escaped_key << "=" << ERB::Util.url_encode(val.to_s)
         end
       end.join('&')
     end

--- a/lib/imgix/version.rb
+++ b/lib/imgix/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Imgix
   VERSION = '1.2.1'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems'
 require 'bundler'
 Bundler.require :test

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DomainsTest < Imgix::Test

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PathTest < Imgix::Test

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UrlTest < Imgix::Test


### PR DESCRIPTION
I was analysing our Rails app memory usage with [derailed](https://github.com/schneems/derailed_benchmarks) and found that `imgix` was one of the biggest memory users:

```
allocated memory by gem
-----------------------------------
   2771909  activerecord-5.2.0
   1947055  dalli-2.7.8
   1886929  activesupport-5.2.0
    794864  psych
    771112  erb
    616881  activemodel-5.2.0
    601592  imgix-1.1.0             <---------
...
```

I found that a lot of the memory usage comes from mutable strings. This pull request addresses that by adding `frozen_string_literal: true` comments.

I also rewrote the `Path#query` with string concatenation instead of string interpolation. This improved performance and memory usage further.

After these changes derailed reports a memory usage of `355424` over `601592`.

<details>
<summary>Performance benchmark</summary>

```ruby
require 'benchmark/ips'
require 'erb'

@options = {
  h: 200,
  w: 240
}

Benchmark.ips do |x|
  x.report('original') do
    @options.map do |key, val|
      escaped_key = ERB::Util.url_encode(key.to_s)

      if escaped_key.end_with? '64'
        base64_encoded_val = Base64.urlsafe_encode64(val.to_s).delete('=')
        "#{escaped_key}=#{base64_encoded_val}"
      else
        "#{escaped_key}=#{ERB::Util.url_encode(val.to_s)}"
      end
    end.join('&')
  end

  x.report('improved') do
    @options.map do |key, val|
      escaped_key = ERB::Util.url_encode(key.to_s)

      if escaped_key.end_with? '64'
        escaped_key << "=" << Base64.urlsafe_encode64(val.to_s).delete('=')
      else
        escaped_key << "=" << ERB::Util.url_encode(val.to_s)
      end
    end.join('&')
  end

  x.compare!
end
```

```
Warming up --------------------------------------
            original    20.125k i/100ms
            improved    14.823k i/100ms
Calculating -------------------------------------
            original    143.937k (±74.1%) i/s -    422.625k in   5.177080s
            improved    165.598k (±57.2%) i/s -    533.628k in   5.038972s

Comparison:
            improved:   165598.2 i/s
            original:   143936.5 i/s - same-ish: difference falls within error
```
</details>