### PR TITLE
Include bundler 2.x in travis pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
     - rvm: rbx-3.107
       env: NEEDS_UPGRADE = true
 before_script:
-  - if $NEEDS_UPGRADE = true; then bundle update --bundler; fi
-  
+  - echo $NEEDS_UPGRADE  
+  - if $NEEDS_UPGRADE == true; then bundle update --bundler; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 bundler_args: --without development
 before_install:
   - gem install bundler -v '< 2'
+  - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
+  - LATEST_VERS=2.3.0
 matrix:
   include:
     - rvm: 2.3.0
@@ -15,5 +17,6 @@ matrix:
     - rvm: rbx-3.107
       env: NEEDS_UPGRADE = true
 before_script:
-  - echo $NEEDS_UPGRADE  
-  - if $NEEDS_UPGRADE == true; then bundle update --bundler; fi
+  - echo $RUBY_VERS 
+  - echo $LATEST_VERS
+  - if (( $(echo "$RUBY_VERS > $LATEST_VERS" | bc -l) )); then bundle update --bundler; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ bundler_args: --without development
 before_install:
   - gem install bundler -v '< 2'
   - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
-  - LATEST_VERS=2.3.0
+  - LATEST_VERS=2.3
 matrix:
   include:
     - rvm: 2.3.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 bundler_args: --without development
 before_install:
   - gem install bundler
-  - rvm get head
 rvm:
   - 2.3.0
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,15 @@ before_install:
   - gem install bundler -v '< 2'
   - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
   - LATEST_VERS=2.3
+  - echo $RUBY_VERS 
+  - echo $LATEST_VERS
+  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
+  - bundler --version
 rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
   - jruby-9.0.5.0
   - rbx-3.107
-before_script:
-  - echo $RUBY_VERS 
-  - echo $LATEST_VERS
-  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
+script:
   - bundler --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,14 @@ before_install:
   - gem install bundler -v '< 2'
   - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
   - LATEST_VERS=2.3
-matrix:
-  include:
-    - rvm: 2.3.0
-      env: NEEDS_UPGRADE = true
-    - rvm: 2.2.4
-      env: NEEDS_UPGRADE = false
-    - rvm: 2.1.8
-      env: NEEDS_UPGRADE = false
-    - rvm: jruby-9.0.5.0
-      env: NEEDS_UPGRADE = false
-    - rvm: rbx-3.107
-      env: NEEDS_UPGRADE = true
+rvm:
+  - 2.3.0
+  - 2.2.4
+  - 2.1.8
+  - jruby-9.0.5.0
+  - rbx-3.107
 before_script:
   - echo $RUBY_VERS 
   - echo $LATEST_VERS
-  - if (( $(echo "$RUBY_VERS > $LATEST_VERS" | bc -l) )); then bundle update --bundler; fi
+  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
+  - bundler --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ before_install:
   - LATEST_VERS=2.3
   - echo $RUBY_VERS 
   - echo $LATEST_VERS
-  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
-  - bundler --version
+  - bundle version
 rvm:
   - 2.3.0
   - 2.2.4
@@ -15,4 +14,7 @@ rvm:
   - jruby-9.0.5.0
   - rbx-3.107
 script:
-  - bundler --version
+  - echo "Done"
+  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
+  - bundle --version
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,13 @@ before_install:
   - echo $RUBY_VERS 
   - echo $LATEST_VERS
   - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(gem install bundler); else echo $(gem install bundler -v '< 2'); fi
-  - bundle version
+  - bundle --version
 rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
   - jruby-9.0.5.0
   - rbx-3.107
-script:
+before_script:
   - echo "Done"
-  - bundle --version
-  - bundle exec rake
+  - cat Gemfile.lock | grep -A 1 "BUNDLED WITH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 bundler_args: --without development
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '< 2'
 rvm:
   - 2.3.0
@@ -9,3 +8,22 @@ rvm:
   - 2.1.8
   - jruby-9.0.5.0
   - rbx-3.107
+matrix:
+  include:
+    - 2.3.0
+    env: RUBY_VERS = 2.3.0
+  include:
+    - 2.2.4
+    env: RUBY_VERS = 2.2.4
+  include:
+    - 2.1.8
+    env: RUBY_VERS = 2.1.8
+  include:
+    - jruby-9.0.5.0
+    env: RUBY_VERS = 2.2
+  include:
+    - rbx-3.107
+    env: RUBY_VERS = 3
+script:
+  if: RUBY_VERS >= 2.3
+  - bundle update --bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
     - rvm: rbx-3.107
       env: NEEDS_UPGRADE = true
 before_script:
-  - if env(NEEDS_UPGRADE) = true; bundle update --bundler; fi
+  - if env(NEEDS_UPGRADE) = true; then bundle update --bundler; fi
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,16 @@ rvm:
   - rbx-3.107
 matrix:
   include:
-    - 2.3.0
-    env: RUBY_VERS = 2.3.0
-  include:
-    - 2.2.4
-    env: RUBY_VERS = 2.2.4
-  include:
-    - 2.1.8
-    env: RUBY_VERS = 2.1.8
-  include:
-    - jruby-9.0.5.0
-    env: RUBY_VERS = 2.2
-  include:
-    - rbx-3.107
-    env: RUBY_VERS = 3
-script:
-  if: RUBY_VERS >= 2.3
-  - bundle update --bundler
+    - rvm: 2.3.0
+      env: RUBY_VERS = 2.3.0
+    - rvm: 2.2.4
+      env: RUBY_VERS = 2.2.4
+    - rvm: 2.1.8
+      env: RUBY_VERS = 2.1.8
+    - rvm: jruby-9.0.5.0
+      env: RUBY_VERS = 2.2
+    - rvm: rbx-3.107
+      env: RUBY_VERS = 3
+before_script:
+  - if env(RUBY_VERS) = true; bundle update --bundler; fi
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,18 @@ language: ruby
 bundler_args: --without development
 before_install:
   - gem install bundler -v '< 2'
-rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
-  - jruby-9.0.5.0
-  - rbx-3.107
 matrix:
   include:
     - rvm: 2.3.0
-      env: RUBY_VERS = 2.3.0
+      env: NEEDS_UPGRADE = true
     - rvm: 2.2.4
-      env: RUBY_VERS = 2.2.4
+      env: NEEDS_UPGRADE = false
     - rvm: 2.1.8
-      env: RUBY_VERS = 2.1.8
+      env: NEEDS_UPGRADE = false
     - rvm: jruby-9.0.5.0
-      env: RUBY_VERS = 2.2
+      env: NEEDS_UPGRADE = false
     - rvm: rbx-3.107
-      env: RUBY_VERS = 3
+      env: NEEDS_UPGRADE = true
 before_script:
-  - if env(RUBY_VERS) = true; bundle update --bundler; fi
+  - if env(NEEDS_UPGRADE) = true; bundle update --bundler; fi
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
 language: ruby
 bundler_args: --without development
 before_install:
+  # Extracts the ruby version number
   - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
+  # Bundler 2.0 requires at least ruby vers 2.3.0
   - LATEST_VERS=2.3
-  - echo $RUBY_VERS 
-  - echo $LATEST_VERS
-  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(gem install bundler); else echo $(gem install bundler -v '< 2'); fi
-  - bundle --version
+  # Based on a given job's ruby version, install either
+  # Bundler 2.x or 1.17
+  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) ));
+      then echo $(gem install bundler); 
+      else echo $(gem install bundler -v '< 2'); 
+    fi
 rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
   - jruby-9.0.5.0
   - rbx-3.107
-before_script:
-  - echo "Done"
-  - cat Gemfile.lock | grep -A 1 "BUNDLED WITH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 bundler_args: --without development
 before_install:
-  - gem install bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.3.0
   - 2.2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: ruby
 bundler_args: --without development
 before_install:
-  - gem install bundler -v '< 2'
   - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
   - LATEST_VERS=2.3
   - echo $RUBY_VERS 
   - echo $LATEST_VERS
+  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(gem install bundler); else echo $(gem install bundler -v '< 2'); fi
   - bundle version
 rvm:
   - 2.3.0
@@ -15,6 +15,5 @@ rvm:
   - rbx-3.107
 script:
   - echo "Done"
-  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) )); then echo $(bundle update --bundler); fi
   - bundle --version
   - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,5 @@ matrix:
     - rvm: rbx-3.107
       env: NEEDS_UPGRADE = true
 before_script:
-  - if env(NEEDS_UPGRADE) = true; then bundle update --bundler; fi
+  - if $NEEDS_UPGRADE = true; then bundle update --bundler; fi
   

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.0'
   
-  bundler_vers = RUBY_VERSION < '2.3' ? '~> 1.17' : '>=2.0'
-  spec.add_development_dependency 'bundler', bundler_vers
+  # bundler_vers = RUBY_VERSION < '2.3' ? '~> 1.17' : '>=2.0'
+  # spec.add_development_dependency 'bundler', bundler_vers
   spec.add_dependency 'addressable'
   spec.add_development_dependency 'webmock'
 end

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -19,6 +19,9 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 1.9.0'
+  
+  bundler_vers = RUBY_VERSION < '2.3' ? '~> 1.17' : '>=2.0'
+  spec.add_development_dependency 'bundler', bundler_vers
   spec.add_dependency 'addressable'
   spec.add_development_dependency 'webmock'
 end

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 1.9.0'
-
   spec.add_dependency 'addressable'
   spec.add_development_dependency 'webmock'
 end

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -19,9 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '>= 1.9.0'
-  
-  # bundler_vers = RUBY_VERSION < '2.3' ? '~> 1.17' : '>=2.0'
-  # spec.add_development_dependency 'bundler', bundler_vers
+
   spec.add_dependency 'addressable'
   spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
With the release of [Bundler 2.0](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html) we want to include cases in travis that will test for both the new and old versions. 
This pull request adds logic at the `before_install` stage that will install a specific version (either `2.x` or `1.17`) based on the ruby version per job.