### PR TITLE
Add domain validation during Client initialization

### DIFF
--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -6,8 +6,8 @@ require 'imgix/version'
 Gem::Specification.new do |spec|
   spec.name          = 'imgix'
   spec.version       = Imgix::VERSION
-  spec.authors       = ['Kelly Sutton', 'Sam Soffes', 'Ryan LeFevre', 'Antony Denyer', 'Paul Straw']
-  spec.email         = ['kelly@imgix.com', 'sam@soff.es', 'ryan@layervault.com', 'email@antonydenyer.co.uk', 'paul@imgix.com']
+  spec.authors       = ['Kelly Sutton', 'Sam Soffes', 'Ryan LeFevre', 'Antony Denyer', 'Paul Straw', 'Sherwin Heydarbeygi']
+  spec.email         = ['kelly@imgix.com', 'sam@soff.es', 'ryan@layervault.com', 'email@antonydenyer.co.uk', 'paul@imgix.com', 'sherwin@imgix.com']
   spec.description   = 'Easily create and sign imgix URLs.'
   spec.summary       = 'Official Ruby Gem for easily creating and signing imgix URLs.'
   spec.homepage      = 'https://github.com/imgix/imgix-rb'

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -6,4 +6,5 @@ require 'imgix/path'
 
 module Imgix
   STRATEGIES = [:crc, :cycle]
+  DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i
 end

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -75,6 +75,11 @@ module Imgix
       unless @hosts.length > 0
         raise ArgumentError, "The :host or :hosts option must be specified"
       end
+      @hosts.each do |host|
+        unless host.match(DOMAIN_REGEX) != nil
+          raise ArgumentError, "Domains must be passed in as fully-qualified domain names and should not include a protocol or any path element, i.e. \"example.imgix.net\"."
+        end
+      end
     end
 
   end

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -49,7 +49,7 @@ module Imgix
     def get_host(path)
       host = host_for_crc(path) if @shard_strategy == :crc
       host = host_for_cycle if @shard_strategy == :cycle
-      host.gsub("http://","").gsub("https://","").chomp("/")
+      host
     end
 
     def host_for_crc(path)
@@ -76,7 +76,7 @@ module Imgix
         raise ArgumentError, "The :host or :hosts option must be specified"
       end
       @hosts.each do |host|
-        unless host.match(DOMAIN_REGEX) != nil
+        if host.match(DOMAIN_REGEX) == nil
           raise ArgumentError, "Domains must be passed in as fully-qualified domain names and should not include a protocol or any path element, i.e. \"example.imgix.net\"."
         end
       end

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -42,24 +42,6 @@ class DomainsTest < Imgix::Test
     assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
   end
 
-  def test_strips_out_protocol
-    client = Imgix::Client.new(host: "http://demos-1.imgix.net",
-      secure_url_token: '10adc394',
-      include_library_param: false)
-
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-  end
-
-  def test_strips_out_trailing_slash
-    client = Imgix::Client.new(host: "http://demos-1.imgix.net/",
-      secure_url_token: '10adc394',
-      include_library_param: false)
-
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-  end
-
   def test_with_full_paths
     client = Imgix::Client.new(hosts: [
         "demos-1.imgix.net",
@@ -72,5 +54,17 @@ class DomainsTest < Imgix::Test
 
     path = 'https://google.com/cats.gif'
     assert_equal "https://demos-1.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
+  end
+
+  def test_invalid_domain_append_slash
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["assets.imgix.net/"])}
+  end
+
+  def test_invalid_domain_prepend_scheme
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["https://assets.imgix.net"])}
+  end
+
+  def test_invalid_domain_append_dash
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["assets.imgix.net-"])}
   end
 end


### PR DESCRIPTION
Adds a validation that will throw an error if a user attempts to initialize a new `Client` object with an invalid domain. 
The validation criteria is based off of the same regex used on [dashboard.imgix.com](https://dashboard.imgix.com)