### PR TITLE
fix: deprecate domain sharding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 
 
 ## Domain Sharded URLs
+**Warning: Domain Sharding has been deprecated and will be removed in the next major release**
 
 Domain sharding enables you to spread image requests across multiple domains. This allows you to bypass the requests-per-host limits of browsers. We recommend 2-3 domain shards maximum if you are going to use domain sharding.
 

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -60,7 +60,9 @@ module Imgix
     end
 
     def host_for_cycle
-      @hosts_cycle = @hosts.cycle unless @hosts_cycle
+      if not defined? @hosts_cycle
+        @hosts_cycle = @hosts.cycle
+      end
       @hosts_cycle.next
     end
 

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -13,6 +13,7 @@ module Imgix
     def initialize(options = {})
       options = DEFAULTS.merge(options)
 
+      deprecate_warning!(options[:host],options[:hosts])
       @hosts = Array(options[:host]) + Array(options[:hosts]) and validate_hosts!
       @secure_url_token = options[:secure_url_token]
       @api_key = options[:api_key]
@@ -82,5 +83,11 @@ module Imgix
       end
     end
 
+    def deprecate_warning!(host, hosts)
+      has_many_domains = (host.kind_of?(Array) && host.length > 1 ) || (hosts.kind_of?(Array) && hosts.length > 1)
+      if has_many_domains
+        warn "Warning: Domain sharding has been deprecated and will be removed in the next major version."
+      end
+    end
   end
 end

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -4,67 +4,86 @@ require 'test_helper'
 
 class DomainsTest < Imgix::Test
   def test_deterministically_choosing_a_path
-    client = Imgix::Client.new(hosts: [
-        "demos-1.imgix.net",
-        "demos-2.imgix.net",
-        "demos-3.imgix.net",
-      ],
-      secure_url_token: '10adc394',
-      include_library_param: false)
+    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
+      client = Imgix::Client.new(hosts: [
+          "demos-1.imgix.net",
+          "demos-2.imgix.net",
+          "demos-3.imgix.net",
+        ],
+        secure_url_token: '10adc394',
+        include_library_param: false)
 
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+      path = client.path('/bridge.png')
+      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
 
-    path = client.path('/flower.png')
-    assert_equal 'https://demos-2.imgix.net/flower.png?s=02105961388864f85c04121ea7b50e08', path.to_url
+      path = client.path('/flower.png')
+      assert_equal 'https://demos-2.imgix.net/flower.png?s=02105961388864f85c04121ea7b50e08', path.to_url
+    }
   end
 
   def test_cycling_choosing_domain_in_order
-    client = Imgix::Client.new(hosts: [
-        "demos-1.imgix.net",
-        "demos-2.imgix.net",
-        "demos-3.imgix.net",
-      ],
-      secure_url_token: '10adc394',
-      shard_strategy: :cycle,
-      include_library_param: false)
+    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
+      client = Imgix::Client.new(hosts: [
+          "demos-1.imgix.net",
+          "demos-2.imgix.net",
+          "demos-3.imgix.net",
+        ],
+        secure_url_token: '10adc394',
+        shard_strategy: :cycle,
+        include_library_param: false)
 
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+      path = client.path('/bridge.png')
+      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
 
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-2.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+      path = client.path('/bridge.png')
+      assert_equal 'https://demos-2.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
 
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-3.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+      path = client.path('/bridge.png')
+      assert_equal 'https://demos-3.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
 
-    path = client.path('/bridge.png')
-    assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+      path = client.path('/bridge.png')
+      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
+    }
   end
 
   def test_with_full_paths
-    client = Imgix::Client.new(hosts: [
-        "demos-1.imgix.net",
-        "demos-2.imgix.net",
-        "demos-3.imgix.net",
-      ],
-      secure_url_token: '10adc394',
-      shard_strategy: :cycle,
-      include_library_param: false)
+    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
+      client = Imgix::Client.new(hosts: [
+          "demos-1.imgix.net",
+          "demos-2.imgix.net",
+          "demos-3.imgix.net",
+        ],
+        secure_url_token: '10adc394',
+        shard_strategy: :cycle,
+        include_library_param: false)
 
-    path = 'https://google.com/cats.gif'
-    assert_equal "https://demos-1.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
+      path = 'https://google.com/cats.gif'
+      assert_equal "https://demos-1.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
+    }
   end
 
   def test_invalid_domain_append_slash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["assets.imgix.net/"])}
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net/")}
   end
 
   def test_invalid_domain_prepend_scheme
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["https://assets.imgix.net"])}
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "https://assets.imgix.net")}
   end
 
   def test_invalid_domain_append_dash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: ["assets.imgix.net-"])}
+    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net-")}
+  end
+
+  def test_domain_sharding_deprecation_host
+
+    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
+      Imgix::Client.new(host: ["assets1.imgix.net", "assets2.imgix.net"])
+    }
+  end
+
+  def test_domain_sharding_deprecation_hosts
+    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
+      Imgix::Client.new(hosts: ["assets1.imgix.net", "assets2.imgix.net"])
+    }
   end
 end


### PR DESCRIPTION
This PR begins the process of deprecating, and eventually removing, domain sharding from the imgix-rb library.
The `Imgix::Client` object will now throw a warning when users attempt to initialize it by passing in multiple domains in the form of an array.