### PR TITLE
fix: add path validation

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -37,6 +37,7 @@ module Imgix
       @path = path
       @options = {}
 
+      validate_path!
       @path = CGI.escape(@path) if /^https?/ =~ @path
       @path = "/#{@path}" if @path[0] != '/'
     end
@@ -107,6 +108,12 @@ module Imgix
 
     def has_query?
       query.length > 0
+    end
+
+    def validate_path!
+      if @path.match(/(\?)/)
+        raise ArgumentError, "Paths cannot be passed in with query parameters included. Use to_url() to append parameters during URL generation."
+      end
     end
   end
 end

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -63,19 +63,27 @@ class DomainsTest < Imgix::Test
   end
 
   def test_invalid_domain_append_slash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net/")}
+    exception = assert_raises(ArgumentError){
+      Imgix::Client.new(hosts: "assets.imgix.net/")
+    }
+    assert_equal("Domains must be passed in as fully-qualified domain names and should not include a protocol or any path element, i.e. \"example.imgix.net\".", exception.message)
   end
 
   def test_invalid_domain_prepend_scheme
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "https://assets.imgix.net")}
+    exception = assert_raises(ArgumentError){
+      Imgix::Client.new(hosts: "https://assets.imgix.net")
+    }
+    assert_equal("Domains must be passed in as fully-qualified domain names and should not include a protocol or any path element, i.e. \"example.imgix.net\".", exception.message)
   end
 
   def test_invalid_domain_append_dash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net-")}
+    exception = assert_raises(ArgumentError){
+      Imgix::Client.new(hosts: "assets.imgix.net-")
+    }
+    assert_equal("Domains must be passed in as fully-qualified domain names and should not include a protocol or any path element, i.e. \"example.imgix.net\".", exception.message)
   end
 
   def test_domain_sharding_deprecation_host
-
     assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
       Imgix::Client.new(host: ["assets1.imgix.net", "assets2.imgix.net"])
     }

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -121,6 +121,13 @@ class PathTest < Imgix::Test
     assert_equal "ixlib=#{library}-#{version}", URI(url).query
   end
 
+  def test_invalid_path_error
+    exception = assert_raises(ArgumentError){
+      client.path('demo.png?w=300')
+    }
+    assert_equal('Paths cannot be passed in with query parameters included. Use to_url() to append parameters during URL generation.', exception.message)
+  end
+
 private
   def client
     @client ||= Imgix::Client.new(host: 'demo.imgix.net', secure_url_token: '10adc394', include_library_param: false)


### PR DESCRIPTION
This PR adds logic to throw an error when the passed-in path includes query parameters. Without path validation, it is possible for users to accidentally generate malformed URLs.

For example:
```rb
client = Imgix::Client.new(host: 'demo.imgix.net')
client.path('assets/image.png?w=300').to_url
# https://demo.imgix.net/assets/image.png?w=300?ixlib=rb-2.0.0
```