### PR TITLE
fix: remove deprecated domain sharding functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Usage
 
-Simply initialize a client with a `:host` or `:hosts` and your `:secure_url_token`. By default, HTTPS URLs are generated, but you can toggle that by passing `use_https: false`.
+Simply initialize a client with a `:host` and your `:secure_url_token`. By default, HTTPS URLs are generated, but you can toggle that by passing `use_https: false`.
 
 Call `Imgix::Client#path` with the resource path to get an `Imgix::Path` object back. You can then manipulate the path parameters, and call `Imgix#Path#to_url` when you're done.
 
@@ -44,29 +44,6 @@ client.path('/images/demo.png').width(200).height(300).to_url
 # Some other tricks
 path.defaults.width(300).to_url # Resets parameters
 path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
-```
-
-
-## Domain Sharded URLs
-**Warning: Domain Sharding has been deprecated and will be removed in the next major release**<br>
-To find out more, see our [blog post](https://blog.imgix.com/2019/05/03/deprecating-domain-sharding) explaining the decision to remove this feature.
-
-Domain sharding enables you to spread image requests across multiple domains. This allows you to bypass the requests-per-host limits of browsers. We recommend 2-3 domain shards maximum if you are going to use domain sharding.
-
-In order to use domain sharding, you need to add multiple domains to your source. You then provide a list of these domains to a builder.
-
-
-``` ruby
-client = Imgix::Client.new(hosts: ['your-subdomain-1.imgix.net',
-  'your-subdomain-2.imgix.net'])
-```
-
-By default, shards are calculated using a checksum so that the image path always resolves to the same domain. This improves caching in the browser. However, you can also specify cycle that simply cycles through the domains as you request them.
-
-
-``` ruby
-client = Imgix::Client.new(hosts: ['your-subdomain-1.imgix.net',
-  'your-subdomain-2.imgix.net'], shard_strategy: :cycle))
 ```
 
 
@@ -103,7 +80,7 @@ For security and diagnostic purposes, we sign all requests with the language and
 This can be disabled by including `include_library_param: false` in the instantiation Hash parameter for `Imgix::Client`:
 
 ```ruby
-client = Imgix::Client.new({ include_library_param: false })
+client = Imgix::Client.new(host: 'your-subdomain.imgix.net', include_library_param: false )
 ```
 
 ## Contributing

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -5,6 +5,5 @@ require 'imgix/client'
 require 'imgix/path'
 
 module Imgix
-  STRATEGIES = [:crc, :cycle]
   DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i
 end

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -3,87 +3,15 @@
 require 'test_helper'
 
 class DomainsTest < Imgix::Test
-  def test_deterministically_choosing_a_path
-    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
-      client = Imgix::Client.new(hosts: [
-          "demos-1.imgix.net",
-          "demos-2.imgix.net",
-          "demos-3.imgix.net",
-        ],
-        secure_url_token: '10adc394',
-        include_library_param: false)
-
-      path = client.path('/bridge.png')
-      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-
-      path = client.path('/flower.png')
-      assert_equal 'https://demos-2.imgix.net/flower.png?s=02105961388864f85c04121ea7b50e08', path.to_url
-    }
-  end
-
-  def test_cycling_choosing_domain_in_order
-    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
-      client = Imgix::Client.new(hosts: [
-          "demos-1.imgix.net",
-          "demos-2.imgix.net",
-          "demos-3.imgix.net",
-        ],
-        secure_url_token: '10adc394',
-        shard_strategy: :cycle,
-        include_library_param: false)
-
-      path = client.path('/bridge.png')
-      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-
-      path = client.path('/bridge.png')
-      assert_equal 'https://demos-2.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-
-      path = client.path('/bridge.png')
-      assert_equal 'https://demos-3.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-
-      path = client.path('/bridge.png')
-      assert_equal 'https://demos-1.imgix.net/bridge.png?s=0233fd6de51f20f11cff6b452b7a9a05', path.to_url
-    }
-  end
-
-  def test_with_full_paths
-    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
-      client = Imgix::Client.new(hosts: [
-          "demos-1.imgix.net",
-          "demos-2.imgix.net",
-          "demos-3.imgix.net",
-        ],
-        secure_url_token: '10adc394',
-        shard_strategy: :cycle,
-        include_library_param: false)
-
-      path = 'https://google.com/cats.gif'
-      assert_equal "https://demos-1.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
-    }
-  end
-
   def test_invalid_domain_append_slash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net/")}
+    assert_raises(ArgumentError) {Imgix::Client.new(host: "assets.imgix.net/")}
   end
 
   def test_invalid_domain_prepend_scheme
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "https://assets.imgix.net")}
+    assert_raises(ArgumentError) {Imgix::Client.new(host: "https://assets.imgix.net")}
   end
 
   def test_invalid_domain_append_dash
-    assert_raises(ArgumentError) {Imgix::Client.new(hosts: "assets.imgix.net-")}
-  end
-
-  def test_domain_sharding_deprecation_host
-
-    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
-      Imgix::Client.new(host: ["assets1.imgix.net", "assets2.imgix.net"])
-    }
-  end
-
-  def test_domain_sharding_deprecation_hosts
-    assert_output(nil, "Warning: Domain sharding has been deprecated and will be removed in the next major version.\n"){
-      Imgix::Client.new(hosts: ["assets1.imgix.net", "assets2.imgix.net"])
-    }
+    assert_raises(ArgumentError) {Imgix::Client.new(host: "assets.imgix.net-")}
   end
 end


### PR DESCRIPTION
This PR removes all domain sharding functionality from imgix-rb, which was deprecated in #43 