### PR TITLE
feat: add srcset generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,48 @@ path.defaults.width(300).to_url # Resets parameters
 path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 ```
 
+## Srcset Generation
+
+The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a menu of image-width mappings.
+
+```rb
+client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
+path = client.path('/images/demo.png')
+
+srcset = path.to_srcset
+```
+
+Will produce the following attribute value, which can then be served to the client:
+
+```html
+https://your-subdomain.imgix.net/images/demo.png?w=100&s=efb3e4ae8eaa1884357f40510b11787c 100w,
+https://your-subdomain.imgix.net/images/demo.png?w=116&s=1417ebeaaaecff39533408cb44893eda 116w,
+https://your-subdomain.imgix.net/images/demo.png?w=134&s=4e45e67c087df930b9ddc8cf5be869d0 134w,
+                                            ...
+https://your-subdomain.imgix.net/images/demo.png?w=7400&s=a5dd7dda1dbac613f0475f1ffd90ef79 7400w,
+https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce3412b64a3452 8192w
+```
+
+In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+
+```rb
+client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
+path = client.path('/images/demo.png')
+
+srcset = path.to_srcset(h:800, ar:'3:2')
+```
+
+Will produce the following attribute value:
+
+```html
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 1x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 2x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 3x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 4x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 5x
+```
+
+For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
 
 ## Multiple Parameters
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 
 ## Srcset Generation
 
-The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a menu of image-width mappings.
+The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
 
 ```rb
 client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -5,5 +5,23 @@ require 'imgix/client'
 require 'imgix/path'
 
 module Imgix
+  # regex pattern used to determine if a domain is valid
   DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i
+
+  # returns an array of width values used during scrset generation
+  TARGET_WIDTHS = lambda {
+    increment_percentage = 8
+    max_size = 8192
+    resolutions = []
+    prev = 100
+
+    while(prev <= max_size)
+      # ensures that each width is even
+      resolutions.push((2 * (prev / 2).round))
+      prev *= 1 + ((increment_percentage.to_f) / 100) * 2
+    end
+
+    resolutions.push(max_size)
+    return resolutions
+  }
 end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -89,16 +89,6 @@ module Imgix
       width = @options['w'.to_sym]
       height = @options['h'.to_sym]
       aspect_ratio = @options['ar'.to_sym]
-      @options.delete('dpr'.to_sym)
-
-      if aspect_ratio 
-        if !aspect_ratio.is_a?(String)
-          raise ArgumentError, "The \'ar\' parameter must be passed a String value"
-        end
-        if aspect_ratio.match(/^\d+(\.\d+)?:\d+(\.\d+)?$/) == nil
-          raise ArgumentError, "The \'ar\' parameter key must follow the format w:h"
-        end
-      end
 
       if ((width) || (height && aspect_ratio))
         build_dpr_srcset(@options)

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -89,6 +89,7 @@ module Imgix
       width = @options['w'.to_sym]
       height = @options['h'.to_sym]
       aspect_ratio = @options['ar'.to_sym]
+      @options.delete('dpr'.to_sym)
 
       if aspect_ratio 
         if !aspect_ratio.is_a?(String)
@@ -99,7 +100,7 @@ module Imgix
         end
       end
 
-      if ((width && height) || (width && aspectRatio) || (height && aspectRatio))
+      if ((width) || (height && aspect_ratio))
         build_dpr_srcset(@options)
       else
         build_srcset_pairs(@options)

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -3,25 +3,6 @@ require 'test_helper'
 module SrcsetTest
 
     class SrcsetDefault < Imgix::Test
-        def test_srcset_removes_dpr
-            srcset = path.to_srcset({dpr:1})
-            srcset.split(',').map { |src|
-                assert_equal (src.include?'dpr='), false
-            }
-        end
-
-        def test_errors_when_ar_format_incorrect
-            assert_raises(ArgumentError) { 
-                path.to_srcset({ar:'3x2'})
-            }
-        end
-
-        def test_errors_when_ar_non_string
-            assert_raises(ArgumentError) { 
-                path.to_srcset({ar:2.5})
-            }
-        end
-
         def test_no_parameters
             srcset = path.to_srcset()
             expected_number_of_pairs = 31

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -198,7 +198,7 @@ module SrcsetTest
     class SrcsetGivenAspectRatioAndHeight < Imgix::Test
         def test_srcset_in_dpr_form
             device_pixel_ratio = 1
-            # puts srcset
+
             srcset.split(',').map { |src|
                 ratio = src.split(' ')[1]
                 assert_equal ("#{device_pixel_ratio}x"), ratio

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -120,7 +120,7 @@ module SrcsetTest
         end
 
         def test_srcset_signs_urls
-            expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+            expected_signature = 'fb081a45c449b28f69e012d474943df3'
 
             srcset.split(',').map { |src|
                 url = src.split(' ')[0]
@@ -133,7 +133,7 @@ module SrcsetTest
 
         private
             def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100,h:100)
             end
     end
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -1,0 +1,239 @@
+require 'test_helper'
+
+module SrcsetTest
+
+    class SrcsetDefault < Imgix::Test
+        def test_srcset_removes_dpr
+            srcset = path.to_srcset({dpr:1})
+            srcset.split(',').map { |src|
+                assert_equal (src.include?'dpr='), false
+            }
+        end
+
+        def test_errors_when_ar_format_incorrect
+            assert_raises(ArgumentError) { 
+                path.to_srcset({ar:'3x2'})
+            }
+        end
+
+        def test_errors_when_ar_non_string
+            assert_raises(ArgumentError) { 
+                path.to_srcset({ar:2.5})
+            }
+        end
+
+        def test_no_parameters
+            srcset = path.to_srcset()
+            expected_number_of_pairs = 31
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+        
+        private
+            def path
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
+            end
+    end
+
+    class SrcsetGivenWidth < Imgix::Test
+        def test_srcset_in_dpr_form
+            device_pixel_ratio = 1
+
+            srcset.split(',').map { |src|
+                ratio = src.split(' ')[1]
+                assert_equal ("#{device_pixel_ratio}x"), ratio
+                device_pixel_ratio += 1
+            }
+        end
+
+        def test_srcset_signs_urls
+            expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+
+            srcset.split(',').map { |src|
+                url = src.split(' ')[0]
+                assert_includes url, "s="
+
+                generated_signature = url.slice(url.index("s=")+2, url.length)
+                assert_equal expected_signature, generated_signature
+            }
+        end
+    
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100)
+            end
+    end
+
+    class SrcsetGivenHeight < Imgix::Test
+        def test_srcset_generates_width_pairs
+            expected_number_of_pairs = 31
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_within_bounds
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length-1].split(' ')[1].to_i
+
+            assert_operator min, :>=, 100
+            assert_operator max, :<=, 8192
+        end
+
+        def test_srcset_iterates_18_percent
+            increment_allowed = 0.18
+
+            # create an array of widths
+            widths = srcset.split(',').map { |src|
+                src.split(' ')[1].to_i
+            }
+
+            prev = widths[0]
+
+            for i in 1..widths.length-1 do
+                element = widths[i]
+                assert_operator (element / prev), :<, (1 + increment_allowed)
+                prev = element
+            end
+        end
+
+        def test_srcset_signs_urls
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, 's='
+
+                # parses out all parameters except for 's=...'
+                params = src.slice(src.index('?'), src.length)
+                params = params.slice(0, params.index('s=')-1)
+                # parses out the 's=...' parameter
+                generated_signature = src.slice(src.index('s=')+2, src.length)
+
+                signature_base = 'MYT0KEN' + '/image.jpg' + params;
+                expected_signature = Digest::MD5.hexdigest(signature_base)
+                
+                assert_equal expected_signature, generated_signature
+            }
+        end
+
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(h:100)
+            end
+    end
+
+    class SrcsetGivenWidthAndHeight < Imgix::Test
+        def test_srcset_in_dpr_form
+            device_pixel_ratio = 1
+
+            srcset.split(',').map { |src|
+                ratio = src.split(' ')[1]
+                assert_equal ("#{device_pixel_ratio}x"), ratio
+                device_pixel_ratio += 1
+            }
+        end
+
+        def test_srcset_signs_urls
+            expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+
+            srcset.split(',').map { |src|
+                url = src.split(' ')[0]
+                assert_includes url, "s="
+
+                generated_signature = url.slice(url.index("s=")+2, url.length)
+                assert_equal expected_signature, generated_signature
+            }
+        end
+
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
+            end
+    end
+
+    class SrcsetGivenAspectRatio < Imgix::Test
+        def test_srcset_generates_width_pairs
+            expected_number_of_pairs = 31
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_within_bounds
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length-1].split(' ')[1].to_i
+
+            assert_operator min, :>=, 100
+            assert_operator max, :<=, 8192
+        end
+
+        def test_srcset_iterates_18_percent
+            increment_allowed = 0.18
+
+            # create an array of widths
+            widths = srcset.split(',').map { |src|
+                src.split(' ')[1].to_i
+            }
+
+            prev = widths[0]
+
+            for i in 1..widths.length-1 do
+                element = widths[i]
+                assert_operator (element / prev), :<, (1 + increment_allowed)
+                prev = element
+            end
+        end
+
+        def test_srcset_signs_urls
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, 's='
+
+                # parses out all parameters except for 's=...'
+                params = src.slice(src.index('?'), src.length)
+                params = params.slice(0, params.index('s=')-1)
+                # parses out the 's=...' parameter
+                generated_signature = src.slice(src.index('s=')+2, src.length)
+
+                signature_base = 'MYT0KEN' + '/image.jpg' + params;
+                expected_signature = Digest::MD5.hexdigest(signature_base)
+                
+                assert_equal expected_signature, generated_signature
+            }
+        end
+
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(ar:'3:2')
+            end
+    end
+
+    class SrcsetGivenAspectRatioAndHeight < Imgix::Test
+        def test_srcset_in_dpr_form
+            device_pixel_ratio = 1
+            # puts srcset
+            srcset.split(',').map { |src|
+                ratio = src.split(' ')[1]
+                assert_equal ("#{device_pixel_ratio}x"), ratio
+                device_pixel_ratio += 1
+            }
+        end
+
+        def test_srcset_signs_urls
+            expected_signature = '84db8cb226483fc0130b4fb58e1e6ff2'
+
+            srcset.split(',').map { |src|
+                url = src.split(' ')[0]
+                assert_includes url, "s="
+
+                generated_signature = url.slice(url.index("s=")+2, url.length)
+                assert_equal expected_signature, generated_signature
+            }
+        end
+
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset({h:100,ar:'3:2'})
+            end
+    end
+end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -69,6 +69,12 @@ module SrcsetTest
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
 
+        def test_srcset_respects_height_parameter
+            srcset.split(',').map { |src|
+                assert_includes src, 'h='
+            }
+        end
+
         def test_srcset_within_bounds
             min, *max = srcset.split(',')
 


### PR DESCRIPTION
This PR creates a new class method in `Path` that will generate a `srcset` string, which can be used in the `srcset` attribute on an `<img>` HTML element. `Imgix::Path#to_srcset` takes a `path` and `params` argument similar to `Imgix::Path#to_url`, and will return a `String` in one of two `srcset` formats.

**Srcset Width-Pairs**
The first format creates `srcset` width-pairs, a comma-delimited list of URLs and width descriptors corresponding to each one. This allows for responsive size switching based on the current width of the browser viewport. `to_srcset` will append any `params` passed to the method to each URL constructed within the list. The following is an example of how to generate a width-pair `srcset`:
```rb
client = Imgix::Client.new(host: 'your-subdomain.imgix.net', include_library_param: false)
path = client.path('/images/demo.png')
srcset = path.to_srcset
```
will return the following `String` (collapsed for brevity):
```html
https://your-subdomain.imgix.net/images/demo.png?w=100 100w,
https://your-subdomain.imgix.net/images/demo.png?w=116 116w,
https://your-subdomain.imgix.net/images/demo.png?w=134 134w,
                                            ...
https://your-subdomain.imgix.net/images/demo.png?w=7400 7400w,
https://your-subdomain.imgix.net/images/demo.png?w=8192 8192w
```
Notice that a `w=` parameter is automatically inserted for each entry in the `srcset` list. This is required in order for the element to properly display the correctly-sized image corresponding to the viewport's width.

**Device Pixel Ratio (DPR) Srcset**
The second format this method can return is a `srcset` list of same-size images in varying resolutions. In this case, images are scaled using the `dpr=` parameter to adjust for the [device pixel ratio](https://docs.imgix.com/apis/url/pixel-density/dpr) of the browser. A DPR `srcset` will be automatically generated instead of a width-pair srcset if exact dimensions for the output image are specified, by providing either a `w` (width) **or** a `h` (height) and `ar` (aspect ratio) in the `params` argument. The following is an example of how to generate a DPR `srcset`:
```rb
client = Imgix::Client.new(host: 'your-subdomain.imgix.net', include_library_param: false)
path = client.path('/images/demo.png')
srcset = path.to_srcset(h:800, ar:'3:2')
```
which will return the following `String`:
```html
https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2 1x,
https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2 2x,
https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2 3x,
https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2 4x,
https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2 5x
```
---
**Signing URLs**
`to_srcset` also supports signing URLs, which can be very useful for generating server-side and then passing it to the client. This will avoid having to expose your imgix source's secure token to the client.
```rb
client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
path = client.path('/images/demo.png')
srcset = path.to_srcset(w:800,)
```
generates a `srcset` with unique signatures for each URL:
```html
https://your-subdomain.imgix.net/images/demo.png?w=800&s=be8c153bb9ed0dd152e846414a8fdc86 1x,
https://your-subdomain.imgix.net/images/demo.png?w=800&s=be8c153bb9ed0dd152e846414a8fdc86 2x,
https://your-subdomain.imgix.net/images/demo.png?w=800&s=be8c153bb9ed0dd152e846414a8fdc86 3x,
https://your-subdomain.imgix.net/images/demo.png?w=800&s=be8c153bb9ed0dd152e846414a8fdc86 4x,
https://your-subdomain.imgix.net/images/demo.png?w=800&s=be8c153bb9ed0dd152e846414a8fdc86 5x
```
---
For more information on `srcset`, building responsive images, and resolution switching:
- [Responsive images - MDN](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images)
- [Srcset and Sizes - Eric Portis](https://ericportis.com/posts/2014/srcset-sizes/)