### PR TITLE
fix: include dpr parameter when generating a DPR srcset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: ruby
 bundler_args: --without development
-before_install:
-  # Extracts the ruby version number
-  - RUBY_VERS="$(bc -l<<<$(ruby -v | cut -d' ' -f 2 | cut -d'.' -f 1,2))"
-  # Bundler 2.0 requires at least ruby vers 2.3.0
-  - LATEST_VERS=2.3
-  # Based on a given job's ruby version, install either
-  # Bundler 2.x or 1.17
-  - if (( $(echo "$RUBY_VERS >= $LATEST_VERS" | bc -l) ));
-      then echo $(gem install bundler); 
-      else echo $(gem install bundler -v '< 2'); 
-    fi
 rvm:
   - 2.3.0
   - 2.2.4

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In cases where enough information is provided about an image's dimensions, `to_s
 client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
 path = client.path('/images/demo.png')
 
-srcset = path.to_srcset(h:800, ar:'3:2')
+srcset = path.to_srcset(h:800, ar:'3:2', fit:'crop')
 ```
 
 Will produce the following attribute value:

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ https://your-subdomain.imgix.net/images/demo.png?w=7400&s=a5dd7dda1dbac613f0475f
 https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce3412b64a3452 8192w
 ```
 
-In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio provided, a different `srcset` will be generated for a fixed-size image instead.
+In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```rb
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
+client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
 path = client.path('/images/demo.png')
 
 srcset = path.to_srcset(h:800, ar:'3:2')
@@ -80,11 +80,11 @@ srcset = path.to_srcset(h:800, ar:'3:2')
 Will produce the following attribute value:
 
 ```html
-https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 1x,
-https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 2x,
-https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 3x,
-https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 4x,
-https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&s=be8c153bb9ed0dd152e846414a8fdc86 5x
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=1&s=f97f2dccf85beac33a3824b57ef4ddc6 1x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=2&s=e1727167fef53cdb0a89dd66b8672410 2x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=3&s=7718db8457345419c30214f1d1a3a5d3 3x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=4&s=000c50a7f97ccdbb9bb2f00bc5241ed4 4x,
+https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=5&s=970b6fc12a410f3dd2959674dd1f4120 5x
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -126,9 +126,9 @@ module Imgix
     def build_srcset_pairs(params = {})
       srcset = ''
       for width in @target_widths do
-        currentParams = params || {}
-        currentParams['w'] = width
-        srcset += "#{to_url(currentParams)} #{width}w,\n"
+        current_params = params || {}
+        current_params['w'] = width
+        srcset += "#{to_url(current_params)} #{width}w,\n"
       end
 
       return srcset[0..-3]
@@ -137,10 +137,11 @@ module Imgix
     def build_dpr_srcset(params = {})
       srcset = ''
       target_ratios = [1,2,3,4,5]
-      url = to_url(params)
 
       for ratio in target_ratios do
-        srcset += "#{url} #{ratio}x,\n"
+        current_params = params
+        current_params['dpr'] = ratio
+        srcset += "#{to_url(params)} #{ratio}x,\n"
       end
 
       return srcset[0..-3]

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -128,25 +128,24 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(params = {})
+    def build_srcset_pairs(params)
       srcset = ''
+
       for width in @target_widths do
-        current_params = params
-        current_params['w'.to_sym] = width
-        srcset += "#{to_url(current_params)} #{width}w,\n"
+        params['w'.to_sym] = width
+        srcset += "#{to_url(params)} #{width}w,\n"
       end
 
       return srcset[0..-3]
     end
 
-    def build_dpr_srcset(params = {})
+    def build_dpr_srcset(params)
       srcset = ''
       target_ratios = [1,2,3,4,5]
 
       for ratio in target_ratios do
-        current_params = params
-        current_params['dpr'.to_sym] = ratio
-        srcset += "#{to_url(current_params)} #{ratio}x,\n"
+        params['dpr'.to_sym] = ratio
+        srcset += "#{to_url(params)} #{ratio}x,\n"
       end
 
       return srcset[0..-3]

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -85,16 +85,21 @@ module Imgix
     end
 
     def to_srcset(params = {})
+      prev_options = @options.dup
       @options.merge!(params)
+
       width = @options['w'.to_sym]
       height = @options['h'.to_sym]
       aspect_ratio = @options['ar'.to_sym]
 
       if ((width) || (height && aspect_ratio))
-        build_dpr_srcset(@options)
+        srcset = build_dpr_srcset(@options)
       else
-        build_srcset_pairs(@options)
+        srcset = build_srcset_pairs(@options)
       end
+
+      @options = prev_options
+      return srcset
     end
     
     private
@@ -126,8 +131,8 @@ module Imgix
     def build_srcset_pairs(params = {})
       srcset = ''
       for width in @target_widths do
-        current_params = params || {}
-        current_params['w'] = width
+        current_params = params
+        current_params['w'.to_sym] = width
         srcset += "#{to_url(current_params)} #{width}w,\n"
       end
 
@@ -140,8 +145,8 @@ module Imgix
 
       for ratio in target_ratios do
         current_params = params
-        current_params['dpr'] = ratio
-        srcset += "#{to_url(params)} #{ratio}x,\n"
+        current_params['dpr'.to_sym] = ratio
+        srcset += "#{to_url(current_params)} #{ratio}x,\n"
       end
 
       return srcset[0..-3]

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -56,8 +56,8 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src.slice(src.index('?'), src.length)
-                params = params.slice(0, params.index('s=')-1)
+                params = src[src.index('?')..src.index('s=')-2]
+
                 # parses out the 's=...' parameter
                 generated_signature = src.slice(src.index('s=')+2, src.length)
 
@@ -134,8 +134,8 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src.slice(src.index('?'), src.length)
-                params = params.slice(0, params.index('s=')-1)
+                params = src[src.index('?')..src.index('s=')-2]
+
                 # parses out the 's=...' parameter
                 generated_signature = src.slice(src.index('s=')+2, src.length)
 
@@ -178,8 +178,8 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src.slice(src.index('?'), src.length)
-                params = params.slice(0, params.index('s=')-1)
+                params = src[src.index('?')..src.index('s=')-2]
+
                 # parses out the 's=...' parameter
                 generated_signature = src.slice(src.index('s=')+2, src.length)
 
@@ -250,8 +250,8 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src.slice(src.index('?'), src.length)
-                params = params.slice(0, params.index('s=')-1)
+                params = src[src.index('?')..src.index('s=')-2]
+
                 # parses out the 's=...' parameter
                 generated_signature = src.slice(src.index('s=')+2, src.length)
 
@@ -294,8 +294,8 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src.slice(src.index('?'), src.length)
-                params = params.slice(0, params.index('s=')-1)
+                params = src[src.index('?')..src.index('s=')-2]
+
                 # parses out the 's=...' parameter
                 generated_signature = src.slice(src.index('s=')+2, src.length)
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -9,6 +9,21 @@ module SrcsetTest
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
         
+        def test_srcset_pair_values
+            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
+            srcset = path.to_srcset()
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length-1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
+        end
+        
         private
             def path
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
@@ -26,14 +41,29 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_dpr_params
+            i = 1
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, "dpr=#{i}"
+                i += 1
+            }
+        end
+
         def test_srcset_signs_urls
-            expected_signature = 'b95cfd915f4a198442bff4ce5befe5b8'
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, 's='
 
-            srcset.split(',').map { |src|
-                url = src.split(' ')[0]
-                assert_includes url, "s="
+                # parses out all parameters except for 's=...'
+                params = src.slice(src.index('?'), src.length)
+                params = params.slice(0, params.index('s=')-1)
+                # parses out the 's=...' parameter
+                generated_signature = src.slice(src.index('s=')+2, src.length)
 
-                generated_signature = url.slice(url.index("s=")+2, url.length)
+                signature_base = 'MYT0KEN' + '/image.jpg' + params;
+                expected_signature = Digest::MD5.hexdigest(signature_base)
+                
                 assert_equal expected_signature, generated_signature
             }
         end
@@ -48,6 +78,20 @@ module SrcsetTest
         def test_srcset_generates_width_pairs
             expected_number_of_pairs = 31
             assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_pair_values
+            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length-1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
         end
 
         def test_srcset_respects_height_parameter
@@ -119,14 +163,29 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_dpr_params
+            i = 1
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, "dpr=#{i}"
+                i += 1
+            }
+        end
+
         def test_srcset_signs_urls
-            expected_signature = 'fb081a45c449b28f69e012d474943df3'
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, 's='
 
-            srcset.split(',').map { |src|
-                url = src.split(' ')[0]
-                assert_includes url, "s="
+                # parses out all parameters except for 's=...'
+                params = src.slice(src.index('?'), src.length)
+                params = params.slice(0, params.index('s=')-1)
+                # parses out the 's=...' parameter
+                generated_signature = src.slice(src.index('s=')+2, src.length)
 
-                generated_signature = url.slice(url.index("s=")+2, url.length)
+                signature_base = 'MYT0KEN' + '/image.jpg' + params;
+                expected_signature = Digest::MD5.hexdigest(signature_base)
+                
                 assert_equal expected_signature, generated_signature
             }
         end
@@ -141,6 +200,20 @@ module SrcsetTest
         def test_srcset_generates_width_pairs
             expected_number_of_pairs = 31
             assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_pair_values
+            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
+                328, 380, 442, 512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946, 2258, 2618,
+                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length-1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
         end
 
         def test_srcset_within_bounds
@@ -206,14 +279,29 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_dpr_params
+            i = 1
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, "dpr=#{i}"
+                i += 1
+            }
+        end
+
         def test_srcset_signs_urls
-            expected_signature = '84db8cb226483fc0130b4fb58e1e6ff2'
+            srcset.split(',').map { |srcset_split|
+                src = srcset_split.split(' ')[0]
+                assert_includes src, 's='
 
-            srcset.split(',').map { |src|
-                url = src.split(' ')[0]
-                assert_includes url, "s="
+                # parses out all parameters except for 's=...'
+                params = src.slice(src.index('?'), src.length)
+                params = params.slice(0, params.index('s=')-1)
+                # parses out the 's=...' parameter
+                generated_signature = src.slice(src.index('s=')+2, src.length)
 
-                generated_signature = url.slice(url.index("s=")+2, url.length)
+                signature_base = 'MYT0KEN' + '/image.jpg' + params;
+                expected_signature = Digest::MD5.hexdigest(signature_base)
+                
                 assert_equal expected_signature, generated_signature
             }
         end


### PR DESCRIPTION
This PR adds a few things that were missed in #47, namely:
- including the dpr parameter when generating a DPR srcset
- mentioning the use of fit=crop in documentation
- more test cases for default (no parameter) calls to buildSrcSet(), expected srcset pair values, and DPR mode
