### PR TITLE
docs: add project metadata to the gemspec

### DIFF
--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -13,6 +13,13 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/imgix/imgix-rb'
   spec.license       = 'MIT'
 
+  spec.metadata = {
+    'bug_tracker_uri'   => 'https://github.com/imgix/imgix-rb/issues',
+    'changelog_uri'     => 'https://github.com/imgix/imgix-rb/blob/master/CHANGELOG.md',
+    'documentation_uri' => "https://www.rubydoc.info/gems/imgix/#{spec.version}",
+    'source_code_uri'   => "https://github.com/imgix/imgix-rb/tree/#{spec.version}"
+  }
+
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
Add [project metadata](https://guides.rubygems.org/specification-reference/#metadata) to the gemspec file. This'll allow people to more easily access the source code, raise issues and read the changelog. These `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `wiki_uri` and `source_code_uri` links will appear on the rubygems page at https://rubygems.org/gems/imgix and be available via the rubygems API after the next release.