### PR TITLE
feat: add ability to configure the srcset width tolerance

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ https://your-subdomain.imgix.net/images/demo.png?w=7400&s=a5dd7dda1dbac613f0475f
 https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce3412b64a3452 8192w
 ```
 
+**Fixed image rendering**
+
 In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```rb
@@ -88,6 +90,25 @@ https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=5&s
 ```
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
+
+**Width Tolerance**
+
+The `srcset` width tolerance dictates the rate at which widths grow between entries in a srcset attribute. By default, this rate is set to 8 percent. This setting can be used to fine tune how many `srcset` pairs are generated when invoking `Imgix::Path#to_srcset`. Users can specify their own width tolerance by passing a positive numeric value using the `width_tolerance` keyword argument:
+
+```rb
+client = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+client.path('image.jpg').to_srcset(width_tolerance: .20)
+```
+
+In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
+
+```
+https://testing.imgix.net/image.jpg?w=100 100w,
+https://testing.imgix.net/image.jpg?w=140 140w,
+https://testing.imgix.net/image.jpg?w=196 196w,
+							...
+https://testing.imgix.net/image.jpg?w=8192 8192w
+```
 
 ## Multiple Parameters
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ By default this rate is set to 8 percent, which we consider to be the ideal rate
 
 ```rb
 client = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-client.path('image.jpg').to_srcset(width_tolerance: .20)
+client.path('image.jpg').to_srcset(width_tolerance: 0.20)
 ```
 
 In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,9 @@ For more information to better understand `srcset`, we highly recommend [Eric Po
 
 **Width Tolerance**
 
-The `srcset` width tolerance dictates the rate at which widths grow between entries in a srcset attribute. By default, this rate is set to 8 percent. This setting can be used to fine tune how many `srcset` pairs are generated when invoking `Imgix::Path#to_srcset`. Users can specify their own width tolerance by passing a positive numeric value using the `width_tolerance` keyword argument:
+The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby reducing rendering artifacts), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
+
+By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by passing a positive numeric value using the `width_tolerance` keyword argument:
 
 ```rb
 client = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -8,9 +8,13 @@ module Imgix
   # regex pattern used to determine if a domain is valid
   DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i
 
+  # determines the growth rate when building out srcset pair widths
+  DEFAULT_WIDTH_TOLERANCE = 8
+
   # returns an array of width values used during scrset generation
-  TARGET_WIDTHS = lambda {
-    increment_percentage = 8
+  TARGET_WIDTHS = lambda { |tolerance|
+    increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE
+
     max_size = 8192
     resolutions = []
     prev = 100

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -9,7 +9,7 @@ module Imgix
   DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i
 
   # determines the growth rate when building out srcset pair widths
-  DEFAULT_WIDTH_TOLERANCE = 8
+  DEFAULT_WIDTH_TOLERANCE = 0.08
 
   # returns an array of width values used during scrset generation
   TARGET_WIDTHS = lambda { |tolerance|
@@ -22,7 +22,7 @@ module Imgix
     while(prev <= max_size)
       # ensures that each width is even
       resolutions.push((2 * (prev / 2).round))
-      prev *= 1 + ((increment_percentage.to_f) / 100) * 2
+      prev *= 1 + (increment_percentage * 2)
     end
 
     resolutions.push(max_size)

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -14,6 +14,9 @@ module Imgix
   # returns an array of width values used during scrset generation
   TARGET_WIDTHS = lambda { |tolerance|
     increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE
+    unless increment_percentage.is_a? Numeric and increment_percentage > 0
+      raise ArgumentError, "The width_tolerance argument must be passed a positive scalar value"
+    end
 
     max_size = 8192
     resolutions = []

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -39,7 +39,7 @@ module Imgix
 
       @path = CGI.escape(@path) if /^https?/ =~ @path
       @path = "/#{@path}" if @path[0] != '/'
-      @target_widths = TARGET_WIDTHS.call
+      @target_widths = TARGET_WIDTHS.call(DEFAULT_WIDTH_TOLERANCE)
     end
 
     def to_url(opts = {})
@@ -130,8 +130,10 @@ module Imgix
 
     def build_srcset_pairs(params)
       srcset = ''
+      width_tolerance = params['width_tolerance'.to_sym]
+      widths = width_tolerance == DEFAULT_WIDTH_TOLERANCE ? @target_widths : TARGET_WIDTHS.call(width_tolerance)
 
-      for width in @target_widths do
+      for width in widths do
         params['w'.to_sym] = width
         srcset += "#{to_url(params)} #{width}w,\n"
       end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -84,7 +84,7 @@ module Imgix
       end
     end
 
-    def to_srcset(params = {})
+    def to_srcset(width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
       prev_options = @options.dup
       @options.merge!(params)
 
@@ -95,7 +95,7 @@ module Imgix
       if ((width) || (height && aspect_ratio))
         srcset = build_dpr_srcset(@options)
       else
-        srcset = build_srcset_pairs(@options)
+        srcset = build_srcset_pairs(width_tolerance: width_tolerance, params: @options)
       end
 
       @options = prev_options
@@ -128,11 +128,14 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(params)
+    def build_srcset_pairs(width_tolerance:, params:)
       srcset = ''
 
-      width_tolerance = params.delete('width_tolerance'.to_sym)
-      widths = width_tolerance == DEFAULT_WIDTH_TOLERANCE ? @target_widths : TARGET_WIDTHS.call(width_tolerance)
+      unless width_tolerance == DEFAULT_WIDTH_TOLERANCE
+        widths = TARGET_WIDTHS.call(width_tolerance)
+      else
+        widths = @target_widths
+      end
 
       for width in widths do
         params['w'.to_sym] = width

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -130,7 +130,8 @@ module Imgix
 
     def build_srcset_pairs(params)
       srcset = ''
-      width_tolerance = params['width_tolerance'.to_sym]
+
+      width_tolerance = params.delete('width_tolerance'.to_sym)
       widths = width_tolerance == DEFAULT_WIDTH_TOLERANCE ? @target_widths : TARGET_WIDTHS.call(width_tolerance)
 
       for width in widths do

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -315,12 +315,12 @@ module SrcsetTest
     end
 
     class SrcsetWidthTolerance < Imgix::Test
-        def test_width_tolerance_generates_width_pairs
+        def test_srcset_generates_width_pairs
             expected_number_of_pairs = 15
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
 
-        def test_width_tolerance_pair_values
+        def test_srcset_pair_values
             resolutions = [100,140,196,274,384,538,752,1054,1476,2066,2892,4050,5670,7938,8192]
             srclist = srcset.split(',').map { |srcset_split|
                 srcset_split.split(' ')[1].to_i
@@ -358,6 +358,22 @@ module SrcsetTest
                 assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
                 prev = element
             end
+        end
+
+        def test_invalid_tolerance_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(width_tolerance: 'abc')
+            }
+        end
+
+        def test_negative_tolerance_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(width_tolerance: -0.10)
+            }
         end
 
         private

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -19,11 +19,11 @@ module SrcsetTest
                 srcset_split.split(' ')[1].to_i
             }
 
-            for i in 0..srclist.length-1 do
+            for i in 0..srclist.length - 1 do
                 assert_equal(srclist[i], resolutions[i])
             end
         end
-        
+
         private
             def path
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
@@ -56,10 +56,10 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=')-2]
+                params = src[src.index('?')..src.index('s=') - 2]
 
                 # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=')+2, src.length)
+                generated_signature = src.slice(src.index('s=') + 2, src.length)
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
@@ -89,7 +89,7 @@ module SrcsetTest
                 srcset_split.split(' ')[1].to_i
             }
 
-            for i in 0..srclist.length-1 do
+            for i in 0..srclist.length - 1 do
                 assert_equal(srclist[i], resolutions[i])
             end
         end
@@ -105,14 +105,15 @@ module SrcsetTest
 
             # parse out the width descriptor as an integer
             min = min.split(' ')[1].to_i
-            max = max[max.length-1].split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
 
             assert_operator min, :>=, 100
             assert_operator max, :<=, 8192
         end
 
-        def test_srcset_iterates_18_percent
-            increment_allowed = 0.18
+        # a 17% testing threshold is used to account for rounding
+        def test_srcset_iterates_17_percent
+            increment_allowed = 0.17
 
             # create an array of widths
             widths = srcset.split(',').map { |src|
@@ -121,7 +122,7 @@ module SrcsetTest
 
             prev = widths[0]
 
-            for i in 1..widths.length-1 do
+            for i in 1..widths.length - 1 do
                 element = widths[i]
                 assert_operator (element / prev), :<, (1 + increment_allowed)
                 prev = element
@@ -134,10 +135,10 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=')-2]
+                params = src[src.index('?')..src.index('s=') - 2]
 
                 # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=')+2, src.length)
+                generated_signature = src.slice(src.index('s=') + 2, src.length)
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
@@ -178,10 +179,10 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=')-2]
+                params = src[src.index('?')..src.index('s=') - 2]
 
                 # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=')+2, src.length)
+                generated_signature = src.slice(src.index('s=') + 2, src.length)
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
@@ -211,7 +212,7 @@ module SrcsetTest
                 srcset_split.split(' ')[1].to_i
             }
 
-            for i in 0..srclist.length-1 do
+            for i in 0..srclist.length - 1 do
                 assert_equal(srclist[i], resolutions[i])
             end
         end
@@ -221,14 +222,15 @@ module SrcsetTest
 
             # parse out the width descriptor as an integer
             min = min.split(' ')[1].to_i
-            max = max[max.length-1].split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
 
             assert_operator min, :>=, 100
             assert_operator max, :<=, 8192
         end
 
-        def test_srcset_iterates_18_percent
-            increment_allowed = 0.18
+        # a 17% testing threshold is used to account for rounding
+        def test_srcset_iterates_17_percent
+            increment_allowed = 0.17
 
             # create an array of widths
             widths = srcset.split(',').map { |src|
@@ -237,7 +239,7 @@ module SrcsetTest
 
             prev = widths[0]
 
-            for i in 1..widths.length-1 do
+            for i in 1..widths.length - 1 do
                 element = widths[i]
                 assert_operator (element / prev), :<, (1 + increment_allowed)
                 prev = element
@@ -250,10 +252,10 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=')-2]
+                params = src[src.index('?')..src.index('s=') - 2]
 
                 # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=')+2, src.length)
+                generated_signature = src.slice(src.index('s=') + 2, src.length)
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
@@ -294,10 +296,10 @@ module SrcsetTest
                 assert_includes src, 's='
 
                 # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=')-2]
+                params = src[src.index('?')..src.index('s=') - 2]
 
                 # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=')+2, src.length)
+                generated_signature = src.slice(src.index('s=') + 2, src.length)
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
@@ -309,6 +311,58 @@ module SrcsetTest
         private
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset({h:100,ar:'3:2'})
+            end
+    end
+
+    class SrcsetWidthTolerance < Imgix::Test
+        def test_width_tolerance_generates_width_pairs
+            expected_number_of_pairs = 15
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_width_tolerance_pair_values
+            resolutions = [100,140,196,274,384,538,752,1054,1476,2066,2892,4050,5670,7938,8192]
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length - 1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
+        end
+
+        def test_srcset_within_bounds
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
+
+            assert_operator min, :>=, 100
+            assert_operator max, :<=, 8192
+        end
+        
+        # a 17% testing threshold is used to account for rounding
+        def test_srcset_iterates_40_percent
+            increment_allowed = 0.42
+
+            # create an array of widths
+            widths = srcset.split(',').map { |src|
+                src.split(' ')[1].to_i
+            }
+
+            prev = widths[0]
+
+            for i in 1..widths.length - 1 do
+                element = widths[i]
+                assert_operator (element / prev), :<, (1 + increment_allowed)
+                prev = element
+            end
+        end
+
+        private
+            def srcset
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 20)
             end
     end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -124,7 +124,7 @@ module SrcsetTest
 
             for i in 1..widths.length - 1 do
                 element = widths[i]
-                assert_operator (element / prev), :<, (1 + increment_allowed)
+                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
                 prev = element
             end
         end
@@ -241,7 +241,7 @@ module SrcsetTest
 
             for i in 1..widths.length - 1 do
                 element = widths[i]
-                assert_operator (element / prev), :<, (1 + increment_allowed)
+                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
                 prev = element
             end
         end
@@ -317,6 +317,7 @@ module SrcsetTest
     class SrcsetWidthTolerance < Imgix::Test
         def test_width_tolerance_generates_width_pairs
             expected_number_of_pairs = 15
+            puts "\n#{srcset}"
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
 
@@ -341,10 +342,10 @@ module SrcsetTest
             assert_operator min, :>=, 100
             assert_operator max, :<=, 8192
         end
-        
-        # a 17% testing threshold is used to account for rounding
-        def test_srcset_iterates_40_percent
-            increment_allowed = 0.42
+
+        # a 41% testing threshold is used to account for rounding
+        def test_srcset_iterates_41_percent
+            increment_allowed = 0.41
 
             # create an array of widths
             widths = srcset.split(',').map { |src|
@@ -355,7 +356,7 @@ module SrcsetTest
 
             for i in 1..widths.length - 1 do
                 element = widths[i]
-                assert_operator (element / prev), :<, (1 + increment_allowed)
+                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
                 prev = element
             end
         end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -376,6 +376,22 @@ module SrcsetTest
             }
         end
 
+        def test_with_param_after
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(width_tolerance: 0.20, h:1000, fit:"clip")
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "width_tolerance="))
+        end
+
+        def test_with_param_before
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(h:1000, fit:"clip", width_tolerance: 0.20)
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "width_tolerance="))
+        end
+
         private
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 0.20)

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -317,7 +317,6 @@ module SrcsetTest
     class SrcsetWidthTolerance < Imgix::Test
         def test_width_tolerance_generates_width_pairs
             expected_number_of_pairs = 15
-            puts "\n#{srcset}"
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
 
@@ -363,7 +362,7 @@ module SrcsetTest
 
         private
             def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 20)
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 0.20)
             end
     end
 end


### PR DESCRIPTION
This PR adds logic which will allow users to modify the width tolerance used when building `srcset` width pairs. More specifically, the width tolerance dictates the maximum allowable percent difference between entries in a `srcset` attribute. By default, this rate is set to 8 percent. Users can use this setting to fine tune how many `srcset` pairs they generate when calling `Imgix::Path#to_srcset`.

A user can now specify their own tolerance rate by passing a percent value to the keyword parameter `width_tolerance`. See the following example:

```rb
client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
client.path('image.jpg').to_srcset(width_tolerance: 0.20)
```
In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a `srcset` pair:
```
https://testing.imgix.net/image.jpg?w=100 100w,
https://testing.imgix.net/image.jpg?w=140 140w,
https://testing.imgix.net/image.jpg?w=196 196w,
							...
https://testing.imgix.net/image.jpg?w=8192 8192w
```