### PR TITLE
feat: add ability to pass in custom widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ https://your-subdomain.imgix.net/images/demo.png?w=7400&s=a5dd7dda1dbac613f0475f
 https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce3412b64a3452 8192w
 ```
 
-**Fixed image rendering**
+### Fixed image rendering
 
 In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
@@ -91,7 +91,28 @@ https://your-subdomain.imgix.net/images/demo.png?h=800&ar=3%3A2&fit=crop&dpr=5&s
 
 For more information to better understand `srcset`, we highly recommend [Eric Portis' "Srcset and sizes" article](https://ericportis.com/posts/2014/srcset-sizes/) which goes into depth about the subject.
 
-**Width Tolerance**
+### Custom Widths
+
+In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of integers to the `widths` keyword argument.
+
+```rb
+@client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+.path('image.jpg')
+.to_srcset(widths: [100, 500, 1000, 1800])
+```
+
+Will generate the following `srcset` of width pairs:
+
+```html
+https://testing.imgix.net/image.jpg?w=100 100w,
+https://testing.imgix.net/image.jpg?w=500 500w,
+https://testing.imgix.net/image.jpg?w=1000 1000w,
+https://testing.imgix.net/image.jpg?w=1800 1800w
+```
+
+Please note that in situations where a `srcset` is being rendered as a [fixed image](#fixed-image-rendering), any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `width_tolerance` are passed to the `to_srcset` method, the custom widths list will take precedence.
+
+### Width Tolerance
 
 The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby reducing rendering artifacts), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -164,9 +164,9 @@ module Imgix
       unless widths.is_a? Array
         raise ArgumentError, "The widths argument must be passed a valid array of integers"
       else
-        valid_integers = widths.all? {|i| i.is_a?(Integer) }
-        unless valid_integers
-          raise ArgumentError, "A custom widths array must only contain integer values"  
+        positive_integers = widths.all? {|i| i.is_a?(Integer) and i > 0}
+        unless positive_integers
+          raise ArgumentError, "A custom widths array must only contain positive integer values"  
         end
       end
     end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -84,7 +84,7 @@ module Imgix
       end
     end
 
-    def to_srcset(width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
+    def to_srcset(sizes: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
       prev_options = @options.dup
       @options.merge!(params)
 
@@ -95,7 +95,7 @@ module Imgix
       if ((width) || (height && aspect_ratio))
         srcset = build_dpr_srcset(@options)
       else
-        srcset = build_srcset_pairs(width_tolerance: width_tolerance, params: @options)
+        srcset = build_srcset_pairs(sizes: sizes, width_tolerance: width_tolerance, params: @options)
       end
 
       @options = prev_options
@@ -128,10 +128,12 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(width_tolerance:, params:)
+    def build_srcset_pairs(sizes:, width_tolerance:, params:)
       srcset = ''
 
-      unless width_tolerance == DEFAULT_WIDTH_TOLERANCE
+      if !sizes.empty?
+        widths = sizes
+      elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE
         widths = TARGET_WIDTHS.call(width_tolerance)
       else
         widths = @target_widths

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -84,7 +84,7 @@ module Imgix
       end
     end
 
-    def to_srcset(sizes: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
+    def to_srcset(widths: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
       prev_options = @options.dup
       @options.merge!(params)
 
@@ -95,7 +95,7 @@ module Imgix
       if ((width) || (height && aspect_ratio))
         srcset = build_dpr_srcset(@options)
       else
-        srcset = build_srcset_pairs(sizes: sizes, width_tolerance: width_tolerance, params: @options)
+        srcset = build_srcset_pairs(widths: widths, width_tolerance: width_tolerance, params: @options)
       end
 
       @options = prev_options
@@ -128,19 +128,19 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(sizes:, width_tolerance:, params:)
+    def build_srcset_pairs(widths:, width_tolerance:, params:)
       srcset = ''
 
-      if !sizes.empty?
-        validate_sizes!(sizes)
-        widths = sizes
+      if !widths.empty?
+        validate_widths!(widths)
+        srcset_widths = widths
       elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE
-        widths = TARGET_WIDTHS.call(width_tolerance)
+        srcset_widths = TARGET_WIDTHS.call(width_tolerance)
       else
-        widths = @target_widths
+        srcset_widths = @target_widths
       end
 
-      for width in widths do
+      for width in srcset_widths do
         params['w'.to_sym] = width
         srcset += "#{to_url(params)} #{width}w,\n"
       end
@@ -160,13 +160,13 @@ module Imgix
       srcset[0..-3]
     end
 
-    def validate_sizes!(sizes)
-      unless sizes.is_a? Array
-        raise ArgumentError, "The sizes argument must be passed a valid array of integers"
+    def validate_widths!(widths)
+      unless widths.is_a? Array
+        raise ArgumentError, "The widths argument must be passed a valid array of integers"
       else
-        valid_integers = sizes.all? {|i| i.is_a?(Integer) }
+        valid_integers = widths.all? {|i| i.is_a?(Integer) }
         unless valid_integers
-          raise ArgumentError, "A custom sizes array must only contain integer values"  
+          raise ArgumentError, "A custom widths array must only contain integer values"  
         end
       end
     end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -132,6 +132,7 @@ module Imgix
       srcset = ''
 
       if !sizes.empty?
+        validate_sizes!(sizes)
         widths = sizes
       elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE
         widths = TARGET_WIDTHS.call(width_tolerance)
@@ -158,5 +159,17 @@ module Imgix
 
       srcset[0..-3]
     end
+
+    def validate_sizes!(sizes)
+      unless sizes.is_a? Array
+        raise ArgumentError, "The sizes argument must be passed a valid array of integers"
+      else
+        valid_integers = sizes.all? {|i| i.is_a?(Integer) }
+        unless valid_integers
+          raise ArgumentError, "A custom sizes array must only contain integer values"  
+        end
+      end
+    end
+
   end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -8,7 +8,7 @@ module SrcsetTest
             expected_number_of_pairs = 31
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
-        
+
         def test_srcset_pair_values
             resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
                 328, 380, 442, 512, 594, 688, 798, 926,
@@ -67,7 +67,7 @@ module SrcsetTest
                 assert_equal expected_signature, generated_signature
             }
         end
-    
+
         private
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100)
@@ -186,7 +186,7 @@ module SrcsetTest
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
-                
+
                 assert_equal expected_signature, generated_signature
             }
         end
@@ -303,7 +303,7 @@ module SrcsetTest
 
                 signature_base = 'MYT0KEN' + '/image.jpg' + params;
                 expected_signature = Digest::MD5.hexdigest(signature_base)
-                
+
                 assert_equal expected_signature, generated_signature
             }
         end
@@ -337,7 +337,6 @@ module SrcsetTest
             # parse out the width descriptor as an integer
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
-
             assert_operator min, :>=, 100
             assert_operator max, :<=, 8192
         end
@@ -383,7 +382,7 @@ module SrcsetTest
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "width_tolerance="))
         end
-
+        
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
@@ -395,6 +394,72 @@ module SrcsetTest
         private
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 0.20)
+            end
+    end
+    class SrcsetCustomSizes < Imgix::Test
+        def test_srcset_generates_width_pairs
+            expected_number_of_pairs = 4
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_pair_values
+            resolutions = [100, 500, 1000, 1800]
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length - 1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
+        end
+
+        def test_srcset_within_bounds
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
+
+            assert_operator min, :>=, @sizes[0]
+            assert_operator max, :<=, @sizes[-1]
+        end
+
+        def test_invalid_sizes_input_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(sizes: 'abc')
+            }
+        end
+
+        def test_non_integer_array_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(sizes: [100, 200, false])
+            }
+        end
+
+        def test_with_param_after
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(sizes: [100, 200, 300], h:1000, fit:"clip")
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "sizes="))
+        end
+
+        def test_with_param_before
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(h:1000, fit:"clip", sizes: [100, 200, 300])
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "sizes="))
+        end
+
+        private
+            def srcset
+                @sizes = [100, 500, 1000, 1800]
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(sizes: @sizes)
             end
     end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -396,7 +396,8 @@ module SrcsetTest
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 0.20)
             end
     end
-    class SrcsetCustomSizes < Imgix::Test
+
+    class SrcsetCustomWidths < Imgix::Test
         def test_srcset_generates_width_pairs
             expected_number_of_pairs = 4
             assert_equal expected_number_of_pairs, srcset.split(',').length
@@ -420,15 +421,15 @@ module SrcsetTest
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
 
-            assert_operator min, :>=, @sizes[0]
-            assert_operator max, :<=, @sizes[-1]
+            assert_operator min, :>=, @widths[0]
+            assert_operator max, :<=, @widths[-1]
         end
 
-        def test_invalid_sizes_input_emits_error
+        def test_invalid_widths_input_emits_error
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(sizes: 'abc')
+                .to_srcset(widths: 'abc')
             }
         end
 
@@ -436,30 +437,34 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(sizes: [100, 200, false])
+                .to_srcset(widths: [100, 200, false])
             }
         end
 
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(sizes: [100, 200, 300], h:1000, fit:"clip")
+            .to_srcset(widths: [100, 200, 300], h:1000, fit:"clip")
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "sizes="))
+            assert(not(srcset.include? "widths="))
         end
 
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", sizes: [100, 200, 300])
+            .to_srcset(h:1000, fit:"clip", widths: [100, 200, 300])
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "sizes="))
+            assert(not(srcset.include? "widths="))
         end
 
         private
             def srcset
-                @sizes = [100, 500, 1000, 1800]
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(sizes: @sizes)
+                @widths = [100, 500, 1000, 1800]
+                @client ||= Imgix::Client.new(
+                    host: 'testing.imgix.net',
+                    include_library_param: false)
+                    .path('image.jpg')
+                    .to_srcset(widths: @widths)
             end
     end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -441,6 +441,14 @@ module SrcsetTest
             }
         end
 
+        def test_negative_integer_array_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(widths: [100, 200, -100])
+            }
+        end
+
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -382,7 +382,7 @@ module SrcsetTest
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "width_tolerance="))
         end
-        
+
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')


### PR DESCRIPTION
This PR adds logic that allows users to pass in a custom widths list when generating srcset pairs.
In certain cases when users know exactly what widths they want to have their images rendered at, they will be able to pass in an array of integers into the `widths:` keyword parameter.
See the following example:

```rb
@client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
.path('image.jpg')
.to_srcset(widths: [100, 500, 1000, 1800])
```
Will generate the following srcset of width-pairs:
```
https://testing.imgix.net/image.jpg?w=100 100w,
https://testing.imgix.net/image.jpg?w=500 500w,
https://testing.imgix.net/image.jpg?w=1000 1000w,
https://testing.imgix.net/image.jpg?w=1800 1800w
```

Please note that in situations where a srcset is being rendered as a fixed image, any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `width_tolerance` are passed in to the `to_srcset` method, the custom widths list will take precedence.