### PR TITLE
feat: support defining a min and max width range

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,32 @@ https://testing.imgix.net/image.jpg?w=196 196w,
 https://testing.imgix.net/image.jpg?w=8192 8192w
 ```
 
+### Min and Max Width Ranges
+
+If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer to either the `min_width` and/or `max_width` keyword parameters:
+
+```rb
+client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+client.path('image.jpg').to_srcset(min_width: 500, max_width: 2000)
+```
+
+Will result in a smaller, more tailored srcset.
+
+```
+https://testing.imgix.net/image.jpg?w=512 512w,
+https://testing.imgix.net/image.jpg?w=594 594w,
+https://testing.imgix.net/image.jpg?w=688 688w,
+https://testing.imgix.net/image.jpg?w=798 798w,
+https://testing.imgix.net/image.jpg?w=926 926w,
+https://testing.imgix.net/image.jpg?w=1074 1074w,
+https://testing.imgix.net/image.jpg?w=1246 1246w,
+https://testing.imgix.net/image.jpg?w=1446 1446w,
+https://testing.imgix.net/image.jpg?w=1678 1678w,
+https://testing.imgix.net/image.jpg?w=1946 1946w
+```
+
+Please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
+
 ## Multiple Parameters
 
 When the imgix api requires multiple parameters you have to use the method rather than an accessor.

--- a/README.md
+++ b/README.md
@@ -135,29 +135,30 @@ https://testing.imgix.net/image.jpg?w=8192 8192w
 
 ### Minimum and Maximum Width Ranges
 
-If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer to either the `min_width` and/or `max_width` keyword parameters:
+If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer to either the `min_srcset` and/or `max_srcset` keyword parameters:
 
 ```rb
 client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
-client.path('image.jpg').to_srcset(min_width: 500, max_width: 2000)
+client.path('image.jpg').to_srcset(min_srcset: 500, max_srcset: 2000)
 ```
 
 Will result in a smaller, more tailored srcset.
 
 ```
-https://testing.imgix.net/image.jpg?w=512 512w,
-https://testing.imgix.net/image.jpg?w=594 594w,
-https://testing.imgix.net/image.jpg?w=688 688w,
-https://testing.imgix.net/image.jpg?w=798 798w,
-https://testing.imgix.net/image.jpg?w=926 926w,
-https://testing.imgix.net/image.jpg?w=1074 1074w,
-https://testing.imgix.net/image.jpg?w=1246 1246w,
-https://testing.imgix.net/image.jpg?w=1446 1446w,
-https://testing.imgix.net/image.jpg?w=1678 1678w,
-https://testing.imgix.net/image.jpg?w=1946 1946w
+https://testing.imgix.net/image.jpg?w=500 500w,
+https://testing.imgix.net/image.jpg?w=580 580w,
+https://testing.imgix.net/image.jpg?w=672 672w,
+https://testing.imgix.net/image.jpg?w=780 780w,
+https://testing.imgix.net/image.jpg?w=906 906w,
+https://testing.imgix.net/image.jpg?w=1050 1050w,
+https://testing.imgix.net/image.jpg?w=1218 1218w,
+https://testing.imgix.net/image.jpg?w=1414 1414w,
+https://testing.imgix.net/image.jpg?w=1640 1640w,
+https://testing.imgix.net/image.jpg?w=1902 1902w,
+https://testing.imgix.net/image.jpg?w=2000 2000w
 ```
 
-Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `max_width: 1000` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
+Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `max_srcset: 1000` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
 
 Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ https://testing.imgix.net/image.jpg?w=196 196w,
 https://testing.imgix.net/image.jpg?w=8192 8192w
 ```
 
-### Min and Max Width Ranges
+### Minimum and Maximum Width Ranges
 
 If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer to either the `min_width` and/or `max_width` keyword parameters:
 
@@ -157,7 +157,9 @@ https://testing.imgix.net/image.jpg?w=1678 1678w,
 https://testing.imgix.net/image.jpg?w=1946 1946w
 ```
 
-Please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
+Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `max_width: 1000` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
+
+Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 
 ## Multiple Parameters
 
@@ -168,7 +170,6 @@ For example to use the noise reduction:
 ``` ruby
 path.noise_reduction(50,50)
 ```
-
 
 ## Purge Cache
 

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -17,15 +17,15 @@ module Imgix
   # the default maximum srcset width, also the max width supported by imgix
   MAX_WIDTH = 8192
   # returns an array of width values used during scrset generation
-  TARGET_WIDTHS = lambda { |tolerance|
+  TARGET_WIDTHS = lambda { |tolerance, min, max|
     increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE
     unless increment_percentage.is_a? Numeric and increment_percentage > 0
       raise ArgumentError, "The width_tolerance argument must be passed a positive scalar value"
     end
 
-    max_size = 8192
+    max_size = max || MAX_WIDTH
     resolutions = []
-    prev = 100
+    prev = min || MIN_WIDTH
 
     while(prev <= max_size)
       # ensures that each width is even

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -11,6 +11,11 @@ module Imgix
   # determines the growth rate when building out srcset pair widths
   DEFAULT_WIDTH_TOLERANCE = 0.08
 
+  # the default minimum srcset width
+  MIN_WIDTH = 100
+
+  # the default maximum srcset width, also the max width supported by imgix
+  MAX_WIDTH = 8192
   # returns an array of width values used during scrset generation
   TARGET_WIDTHS = lambda { |tolerance|
     increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -84,7 +84,7 @@ module Imgix
       end
     end
 
-    def to_srcset(widths: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, **params)
+    def to_srcset(widths: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, min_width: MIN_WIDTH, max_width: MAX_WIDTH, **params)
       prev_options = @options.dup
       @options.merge!(params)
 
@@ -95,7 +95,7 @@ module Imgix
       if ((width) || (height && aspect_ratio))
         srcset = build_dpr_srcset(@options)
       else
-        srcset = build_srcset_pairs(widths: widths, width_tolerance: width_tolerance, params: @options)
+        srcset = build_srcset_pairs(widths: widths, width_tolerance: width_tolerance, min_width: min_width, max_width: max_width, params: @options)
       end
 
       @options = prev_options
@@ -128,7 +128,7 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(widths:, width_tolerance:, params:)
+    def build_srcset_pairs(widths:, width_tolerance:, min_width:, max_width:, params:)
       srcset = ''
 
       if !widths.empty?
@@ -171,5 +171,14 @@ module Imgix
       end
     end
 
+    def validate_range!(min_width, max_width)
+      if min_width.is_a? Numeric and max_width.is_a? Numeric
+        unless min_width > 0 and max_width > 0
+          raise ArgumentError, "The min and max arguments must be passed positive Numeric values"
+        end
+      else
+        raise ArgumentError, "The min and max arguments must be passed positive Numeric values"
+      end
+    end
   end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -478,13 +478,12 @@ module SrcsetTest
 
     class SrcsetMinMaxWidths < Imgix::Test
         def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 10
+            expected_number_of_pairs = 11
             assert_equal expected_number_of_pairs, srcset.split(',').length
         end
 
         def test_srcset_pair_values
-            resolutions = [512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946]
+            resolutions = [500,580,672,780,906,1050,1218,1414,1640,1902,2000]
             srclist = srcset.split(',').map { |srcset_split|
                 srcset_split.split(' ')[1].to_i
             }
@@ -507,7 +506,7 @@ module SrcsetTest
 
         # a 41% testing threshold is used to account for rounding
         def test_with_custom_width_tolerance
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(min_width: 500, max_width: 2000, width_tolerance: 0.20)
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(min_srcset: 500, max_srcset: 2000, width_tolerance: 0.20)
 
             increment_allowed = 0.41
 
@@ -529,7 +528,7 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(min_width: 'abc')
+                .to_srcset(min_srcset: 'abc')
             }
         end
 
@@ -537,34 +536,34 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(max_width: -100)
+                .to_srcset(max_srcset: -100)
             }
         end
 
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(min_width: 500, max_width:2000, h:1000, fit:"clip")
+            .to_srcset(min_srcset: 500, max_srcset:2000, h:1000, fit:"clip")
 
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_width="))
-            assert(not(srcset.include? "max_width="))
+            assert(not(srcset.include? "min_srcset="))
+            assert(not(srcset.include? "max_srcset="))
         end
 
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", min_width: 500, max_width:2000)
+            .to_srcset(h:1000, fit:"clip", min_srcset: 500, max_srcset:2000)
 
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_width="))
-            assert(not(srcset.include? "max_width="))
+            assert(not(srcset.include? "min_srcset="))
+            assert(not(srcset.include? "max_srcset="))
         end
 
         def test_only_min
-            min_width = 1000
-            max_width = 8192
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_width: min_width)
+            min_srcset = 1000
+            max_srcset = 8192
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_srcset: min_srcset)
 
             min, *max = srcset.split(',')
 
@@ -572,22 +571,22 @@ module SrcsetTest
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
 
-            assert_operator min, :>=, min_width
-            assert_operator max, :<=, max_width
+            assert_operator min, :>=, min_srcset
+            assert_operator max, :<=, max_srcset
         end
 
         def test_only_max
-            min_width = 100
-            max_width = 1000
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(max_width: max_width)
+            min_srcset = 100
+            max_srcset = 1000
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(max_srcset: max_srcset)
             min, *max = srcset.split(',')
 
             # parse out the width descriptor as an integer
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
 
-            assert_operator min, :>=, min_width
-            assert_operator max, :<=, max_width
+            assert_operator min, :>=, min_srcset
+            assert_operator max, :<=, max_srcset
 
         end
 
@@ -595,7 +594,7 @@ module SrcsetTest
             def srcset
                 @MIN = 500
                 @MAX = 2000
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_width: @MIN, max_width: @MAX)
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_srcset: @MIN, max_srcset: @MAX)
             end
     end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -475,4 +475,97 @@ module SrcsetTest
                     .to_srcset(widths: @widths)
             end
     end
+
+    class SrcsetMinMaxWidths < Imgix::Test
+        def test_srcset_generates_width_pairs
+            expected_number_of_pairs = 10
+            assert_equal expected_number_of_pairs, srcset.split(',').length
+        end
+
+        def test_srcset_pair_values
+            resolutions = [512, 594, 688, 798, 926,
+                1074, 1246, 1446, 1678, 1946]
+            srclist = srcset.split(',').map { |srcset_split|
+                srcset_split.split(' ')[1].to_i
+            }
+
+            for i in 0..srclist.length - 1 do
+                assert_equal(srclist[i], resolutions[i])
+            end
+        end
+
+        def test_srcset_within_bounds
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
+
+            assert_operator min, :>=, @MIN
+            assert_operator max, :<=, @MAX
+        end
+
+        # a 41% testing threshold is used to account for rounding
+        def test_with_custom_width_tolerance
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(min_width: 500, max_width: 2000, width_tolerance: 0.20)
+
+            increment_allowed = 0.41
+
+            # create an array of widths
+            widths = srcset.split(',').map { |src|
+                src.split(' ')[1].to_i
+            }
+
+            prev = widths[0]
+
+            for i in 1..widths.length - 1 do
+                element = widths[i]
+                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
+                prev = element
+            end
+        end
+
+        def test_invalid_min_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(min_width: 'abc')
+            }
+        end
+
+        def test_negative_max_emits_error
+            assert_raises(ArgumentError) {
+                Imgix::Client.new(host: 'testing.imgix.net')
+                .path('image.jpg')
+                .to_srcset(max_width: -100)
+            }
+        end
+
+        def test_with_param_after
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(min_width: 500, max_width:2000, h:1000, fit:"clip")
+
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "min_width="))
+            assert(not(srcset.include? "max_width="))
+        end
+
+        def test_with_param_before
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+            .path('image.jpg')
+            .to_srcset(h:1000, fit:"clip", min_width: 500, max_width:2000)
+
+            assert_includes(srcset, "h=")
+            assert(not(srcset.include? "min_width="))
+            assert(not(srcset.include? "max_width="))
+        end
+
+        private
+            def srcset
+                @MIN = 500
+                @MAX = 2000
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_width: @MIN, max_width: @MAX)
+            end
+    end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -561,6 +561,36 @@ module SrcsetTest
             assert(not(srcset.include? "max_width="))
         end
 
+        def test_only_min
+            min_width = 1000
+            max_width = 8192
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_width: min_width)
+
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
+
+            assert_operator min, :>=, min_width
+            assert_operator max, :<=, max_width
+        end
+
+        def test_only_max
+            min_width = 100
+            max_width = 1000
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(max_width: max_width)
+            min, *max = srcset.split(',')
+
+            # parse out the width descriptor as an integer
+            min = min.split(' ')[1].to_i
+            max = max[max.length - 1].split(' ')[1].to_i
+
+            assert_operator min, :>=, min_width
+            assert_operator max, :<=, max_width
+
+        end
+
         private
             def srcset
                 @MIN = 500


### PR DESCRIPTION
This PR adds logic to support specifying a minimum and/or maximum width range when generating srcset pairs. In certain situations where the exact min and/or max renderable sizes is known, a user may want to tailor their srcset list to be more concise. This is now possible by passing a positive `Numeric` value to either the `min_srcset` or `max_srcset` keyword parameters when invoking `Imgix::Path#to_srcset`:

```rb
client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
client.path('image.jpg').to_srcset(min_srcset: 500, max_srcset: 2000)
```

Will narrow down the number of entries based on the 

```
https://testing.imgix.net/image.jpg?w=500 500w,
https://testing.imgix.net/image.jpg?w=580 580w,
https://testing.imgix.net/image.jpg?w=672 672w,
https://testing.imgix.net/image.jpg?w=780 780w,
https://testing.imgix.net/image.jpg?w=906 906w,
https://testing.imgix.net/image.jpg?w=1050 1050w,
https://testing.imgix.net/image.jpg?w=1218 1218w,
https://testing.imgix.net/image.jpg?w=1414 1414w,
https://testing.imgix.net/image.jpg?w=1640 1640w,
https://testing.imgix.net/image.jpg?w=1902 1902w,
https://testing.imgix.net/image.jpg?w=2000 2000w
```