### PR TITLE
refactor: pass srcset modifiers through the `options` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ For more information to better understand `srcset`, we highly recommend [Eric Po
 
 ### Custom Widths
 
-In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of integers to the `widths` keyword argument.
+In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of integers via `widths` to the `options` keyword argument.
 
 ```rb
 @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
 .path('image.jpg')
-.to_srcset(widths: [100, 500, 1000, 1800])
+.to_srcset(options: { widths: [100, 500, 1000, 1800] })
 ```
 
 Will generate the following `srcset` of width pairs:
@@ -110,17 +110,17 @@ https://testing.imgix.net/image.jpg?w=1000 1000w,
 https://testing.imgix.net/image.jpg?w=1800 1800w
 ```
 
-Please note that in situations where a `srcset` is being rendered as a [fixed image](#fixed-image-rendering), any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `width_tolerance` are passed to the `to_srcset` method, the custom widths list will take precedence.
+Please note that in situations where a `srcset` is being rendered as a [fixed image](#fixed-image-rendering), any custom `widths` passed in will be ignored. Additionally, if both `widths` and a `width_tolerance` are passed to the `options` parameter in the `to_srcset` method, the custom widths list will take precedence.
 
 ### Width Tolerance
 
 The `srcset` width tolerance dictates the maximum tolerated size difference between an image's downloaded size and its rendered size. For example: setting this value to 0.1 means that an image will not render more than 10% larger or smaller than its native size. In practice, the image URLs generated for a width-based srcset attribute will grow by twice this rate. A lower tolerance means images will render closer to their native size (thereby reducing rendering artifacts), but a large srcset list will be generated and consequently users may experience lower rates of cache-hit for pre-rendered images on your site.
 
-By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by passing a positive numeric value using the `width_tolerance` keyword argument:
+By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by passing a positive numeric value to `width_tolerance` within the `options` keyword argument:
 
 ```rb
 client = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-client.path('image.jpg').to_srcset(width_tolerance: 0.20)
+client.path('image.jpg').to_srcset(options: { width_tolerance: 0.20 })
 ```
 
 In this case, the `width_tolerance` is set to 20 percent, which will be reflected in the difference between subsequent widths in a srcset pair:
@@ -135,11 +135,11 @@ https://testing.imgix.net/image.jpg?w=8192 8192w
 
 ### Minimum and Maximum Width Ranges
 
-If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer to either the `min_srcset` and/or `max_srcset` keyword parameters:
+If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer via `min_srcset` and/or `max_srcset` to the `options` keyword parameters:
 
 ```rb
 client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
-client.path('image.jpg').to_srcset(min_srcset: 500, max_srcset: 2000)
+client.path('image.jpg').to_srcset(options: { min_srcset: 500, max_srcset: 2000 })
 ```
 
 Will result in a smaller, more tailored srcset.
@@ -158,7 +158,7 @@ https://testing.imgix.net/image.jpg?w=1902 1902w,
 https://testing.imgix.net/image.jpg?w=2000 2000w
 ```
 
-Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `max_srcset: 1000` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
+Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
 
 Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -84,7 +84,7 @@ module Imgix
       end
     end
 
-    def to_srcset(widths: [], width_tolerance: DEFAULT_WIDTH_TOLERANCE, min_srcset: MIN_WIDTH, max_srcset: MAX_WIDTH, **params)
+    def to_srcset(options: {}, **params)
       prev_options = @options.dup
       @options.merge!(params)
 
@@ -95,7 +95,7 @@ module Imgix
       if ((width) || (height && aspect_ratio))
         srcset = build_dpr_srcset(@options)
       else
-        srcset = build_srcset_pairs(widths: widths, width_tolerance: width_tolerance, min_srcset: min_srcset, max_srcset: max_srcset, params: @options)
+        srcset = build_srcset_pairs(options: options, params: @options)
       end
 
       @options = prev_options
@@ -128,14 +128,19 @@ module Imgix
       query.length > 0
     end
 
-    def build_srcset_pairs(widths:, width_tolerance:, min_srcset:, max_srcset:, params:)
+    def build_srcset_pairs(options:, params:)
       srcset = ''
+
+      widths = options['widths'.to_sym] || []
+      width_tolerance = options['width_tolerance'.to_sym] ||  DEFAULT_WIDTH_TOLERANCE
+      min_srcset = options['min_width'.to_sym] || MIN_WIDTH
+      max_srcset = options['max_width'.to_sym] || MAX_WIDTH
 
       if !widths.empty?
         validate_widths!(widths)
         srcset_widths = widths
       elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE or min_srcset != MIN_WIDTH or max_srcset != MAX_WIDTH
-        validate_range!(min_srcset,max_srcset)        
+        validate_range!(min_srcset, max_srcset)
         srcset_widths = TARGET_WIDTHS.call(width_tolerance, min_srcset, max_srcset)
       else
         srcset_widths = @target_widths

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -363,7 +363,7 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(width_tolerance: 'abc')
+                .to_srcset(options: {width_tolerance: 'abc'})
             }
         end
 
@@ -371,14 +371,14 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(width_tolerance: -0.10)
+                .to_srcset(options: {width_tolerance: -0.10})
             }
         end
 
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(width_tolerance: 0.20, h:1000, fit:"clip")
+            .to_srcset(options: {width_tolerance: 0.20}, h:1000, fit:"clip")
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "width_tolerance="))
         end
@@ -386,14 +386,14 @@ module SrcsetTest
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", width_tolerance: 0.20)
+            .to_srcset(h:1000, fit:"clip", options: {width_tolerance: 0.20})
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "width_tolerance="))
         end
 
         private
             def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(width_tolerance: 0.20)
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(options: {width_tolerance: 0.20})
             end
     end
 
@@ -429,7 +429,7 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(widths: 'abc')
+                .to_srcset(options: {widths: 'abc'})
             }
         end
 
@@ -437,7 +437,7 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(widths: [100, 200, false])
+                .to_srcset(options: {widths: [100, 200, false]})
             }
         end
 
@@ -445,14 +445,14 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(widths: [100, 200, -100])
+                .to_srcset(options: {widths: [100, 200, -100]})
             }
         end
 
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(widths: [100, 200, 300], h:1000, fit:"clip")
+            .to_srcset(options: {widths: [100, 200, 300]}, h:1000, fit:"clip")
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "widths="))
         end
@@ -460,7 +460,7 @@ module SrcsetTest
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", widths: [100, 200, 300])
+            .to_srcset(h:1000, fit:"clip", options: {widths: [100, 200, 300]})
             assert_includes(srcset, "h=")
             assert(not(srcset.include? "widths="))
         end
@@ -472,7 +472,7 @@ module SrcsetTest
                     host: 'testing.imgix.net',
                     include_library_param: false)
                     .path('image.jpg')
-                    .to_srcset(widths: @widths)
+                    .to_srcset(options: {widths: @widths})
             end
     end
 
@@ -506,7 +506,7 @@ module SrcsetTest
 
         # a 41% testing threshold is used to account for rounding
         def test_with_custom_width_tolerance
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(min_srcset: 500, max_srcset: 2000, width_tolerance: 0.20)
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: 500, max_width: 2000, width_tolerance: 0.20})
 
             increment_allowed = 0.41
 
@@ -528,7 +528,7 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(min_srcset: 'abc')
+                .to_srcset(options: {min_width: 'abc'})
             }
         end
 
@@ -536,34 +536,34 @@ module SrcsetTest
             assert_raises(ArgumentError) {
                 Imgix::Client.new(host: 'testing.imgix.net')
                 .path('image.jpg')
-                .to_srcset(max_srcset: -100)
+                .to_srcset(options: {max_width: -100})
             }
         end
 
         def test_with_param_after
             srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(min_srcset: 500, max_srcset:2000, h:1000, fit:"clip")
+            .to_srcset(options: {min_width: 500, max_width:2000}, h:1000, fit:"clip")
 
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_srcset="))
-            assert(not(srcset.include? "max_srcset="))
+            assert(not(srcset.include? "min_width="))
+            assert(not(srcset.include? "max_width="))
         end
 
         def test_with_param_before
             srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
             .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", min_srcset: 500, max_srcset:2000)
+            .to_srcset(h:1000, fit:"clip", options: {min_width: 500, max_width:2000})
 
             assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_srcset="))
-            assert(not(srcset.include? "max_srcset="))
+            assert(not(srcset.include? "min_width="))
+            assert(not(srcset.include? "max_width="))
         end
 
         def test_only_min
-            min_srcset = 1000
-            max_srcset = 8192
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_srcset: min_srcset)
+            min_width = 1000
+            max_width = 8192
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: min_width})
 
             min, *max = srcset.split(',')
 
@@ -571,22 +571,22 @@ module SrcsetTest
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
 
-            assert_operator min, :>=, min_srcset
-            assert_operator max, :<=, max_srcset
+            assert_operator min, :>=, min_width
+            assert_operator max, :<=, max_width
         end
 
         def test_only_max
-            min_srcset = 100
-            max_srcset = 1000
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(max_srcset: max_srcset)
+            min_width = 100
+            max_width = 1000
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {max_width: max_width})
             min, *max = srcset.split(',')
 
             # parse out the width descriptor as an integer
             min = min.split(' ')[1].to_i
             max = max[max.length - 1].split(' ')[1].to_i
 
-            assert_operator min, :>=, min_srcset
-            assert_operator max, :<=, max_srcset
+            assert_operator min, :>=, min_width
+            assert_operator max, :<=, max_width
 
         end
 
@@ -594,7 +594,7 @@ module SrcsetTest
             def srcset
                 @MIN = 500
                 @MAX = 2000
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(min_srcset: @MIN, max_srcset: @MAX)
+                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: @MIN, max_width: @MAX})
             end
     end
 end


### PR DESCRIPTION
This PR refactors how the new srcset modifier options (see #54, #55, and #56) are required to be passed to `Imgix::Path#to_srcset`. Instead of passing values directly through `widths`, `width_tolerance`, `min_srcset`, and/or `max_srcset` keyword parameters, users should now store any combination of these arguments in the new `options` parameter as a hash.
This change is being made to avoid confusion in naming between imgix URL parameters and parameters that modify object behavior. This should hopefully clarify through design of the interface which options modify how srcsets are generated versus how the image itself is modified through imgix's service.

Example:

```rb
client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg')
client.to_srcset(options: {min_width: 500, max_width: 2000, width_tolerance: 0.20})
```

Will output the following:

```
https://testing.imgix.net/image.jpg?w=500&s=e39b3eddc94ae9f21c2d5ed5772c788e 500w,
https://testing.imgix.net/image.jpg?w=700&s=9c76f8c8fde1de38ddf85c2472ca6289 700w,
https://testing.imgix.net/image.jpg?w=980&s=2416cecd450f40f4a31b6af233d47d91 980w,
https://testing.imgix.net/image.jpg?w=1372&s=73ddbeace48bcb265ea1f24d2111e7e8 1372w,
https://testing.imgix.net/image.jpg?w=1920&s=0a3a9652aeae2262950c22cef2d97adf 1920w,
https://testing.imgix.net/image.jpg?w=2000&s=e51013d2c46f98c0f1b845a042d4caf2 2000w
```