### PR TITLE
feat: append variable qualities to dpr srcsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,30 @@ Remember that browsers will apply a device pixel ratio as a multiplier when sele
 
 Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 
+### Variable Qualities
+
+This gem will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a [fixed-image](https://github.com/imgix/imgix-rb#fixed-image-rendering) srcset. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).
+
+This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `options: { disable_variable_qualities: true }` to `Imgix:Path#to_srcset`.
+
+This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-rb#fixed-image-rendering) is rendered, for example:
+
+```rb
+srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+.path('image.jpg')
+.to_srcset(w:100)
+```
+
+will generate a srcset with the following `q` to `dpr` mapping:
+
+```html
+https://testing.imgix.net/image.jpg?w=100&dpr=1&q=75 1x,
+https://testing.imgix.net/image.jpg?w=100&dpr=2&q=50 2x,
+https://testing.imgix.net/image.jpg?w=100&dpr=3&q=35 3x,
+https://testing.imgix.net/image.jpg?w=100&dpr=4&q=23 4x,
+https://testing.imgix.net/image.jpg?w=100&dpr=5&q=20 5x
+```
+
 ## Multiple Parameters
 
 When the imgix api requires multiple parameters you have to use the method rather than an accessor.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Also please note that according to the [imgix API](https://docs.imgix.com/apis/u
 
 This gem will automatically append a variable `q` parameter mapped to each `dpr` parameter when generating a [fixed-image](https://github.com/imgix/imgix-rb#fixed-image-rendering) srcset. This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).
 
-This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `options: { disable_variable_qualities: true }` to `Imgix:Path#to_srcset`.
+This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `options: { disable_variable_quality: true }` to `Imgix:Path#to_srcset`.
 
 This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-rb#fixed-image-rendering) is rendered, for example:
 

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -38,6 +38,12 @@ module Imgix
     return resolutions
   }
 
-  # default array of quality parameter values mapped to each dpr srcset entry
-  DPR_QUALITY = [75, 50, 35, 23, 20]
+  # hash of default quality parameter values mapped  by each dpr srcset entry
+  DPR_QUALITY = {
+    1 => 75, 
+    2 => 50,
+    3 => 35,
+    4 => 23,
+    5 => 20
+  }
 end

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -16,6 +16,7 @@ module Imgix
 
   # the default maximum srcset width, also the max width supported by imgix
   MAX_WIDTH = 8192
+
   # returns an array of width values used during scrset generation
   TARGET_WIDTHS = lambda { |tolerance, min, max|
     increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE
@@ -36,4 +37,7 @@ module Imgix
     resolutions.push(max_size)
     return resolutions
   }
+
+  # default array of quality parameter values mapped to each dpr srcset entry
+  DPR_QUALITY = [75, 50, 35, 23, 20]
 end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -157,9 +157,13 @@ module Imgix
     def build_dpr_srcset(params)
       srcset = ''
       target_ratios = [1,2,3,4,5]
+      quality = params['q'.to_sym]
 
-      for ratio in target_ratios do
-        params['dpr'.to_sym] = ratio
+      for index in 0..target_ratios.length - 1 do
+        ratio = target_ratios[index]
+
+        params['dpr'.to_sym] = ratio 
+        params['q'.to_sym] = quality || DPR_QUALITY[index]
         srcset += "#{to_url(params)} #{ratio}x,\n"
       end
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -163,12 +163,11 @@ module Imgix
       target_ratios = [1,2,3,4,5]
       quality = params['q'.to_sym]
 
-      for index in 0..target_ratios.length - 1 do
-        ratio = target_ratios[index]
+      for ratio in target_ratios do
         params['dpr'.to_sym] = ratio
 
         unless disable_variable_quality
-          params['q'.to_sym] = quality || DPR_QUALITY[index + 1]
+          params['q'.to_sym] = quality || DPR_QUALITY[ratio]
         end
 
         srcset += "#{to_url(params)} #{ratio}x,\n"

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -157,8 +157,8 @@ module Imgix
     def build_dpr_srcset(options:, params:)
       srcset = ''
 
-      disable_variable_qualities = options['disable_variable_qualities'.to_sym] || false
-      validate_variable_qualities!(disable_variable_qualities)
+      disable_variable_quality = options['disable_variable_quality'.to_sym] || false
+      validate_variable_qualities!(disable_variable_quality)
 
       target_ratios = [1,2,3,4,5]
       quality = params['q'.to_sym]
@@ -167,8 +167,8 @@ module Imgix
         ratio = target_ratios[index]
         params['dpr'.to_sym] = ratio
 
-        unless disable_variable_qualities
-          params['q'.to_sym] = quality || DPR_QUALITY[index]
+        unless disable_variable_quality
+          params['q'.to_sym] = quality || DPR_QUALITY[index + 1]
         end
 
         srcset += "#{to_url(params)} #{ratio}x,\n"
@@ -198,9 +198,9 @@ module Imgix
       end
     end
 
-    def validate_variable_qualities!(disable_variable_qualities)
-      unless disable_variable_qualities.is_a?(TrueClass) || disable_variable_qualities.is_a?(FalseClass)
-        raise ArgumentError, "The disable_variable_qualities argument must be passed a Boolean value"
+    def validate_variable_qualities!(disable_variable_quality)
+      unless disable_variable_quality.is_a?(TrueClass) || disable_variable_quality.is_a?(FalseClass)
+        raise ArgumentError, "The disable_variable_quality argument must be passed a Boolean value"
       end
     end
   end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -86,7 +86,7 @@ module SrcsetTest
         end
 
         def test_disable_variable_qualities
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100 options: { disable_variable_qualities: true })
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, options: { disable_variable_qualities: true })
 
             srcset.split(',').map { |src|
                 assert(not(src.include? "q="))

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -85,6 +85,14 @@ module SrcsetTest
             }
         end
 
+        def test_disable_variable_qualities
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100 options: { disable_variable_qualities: true })
+
+            srcset.split(',').map { |src|
+                assert(not(src.include? "q="))
+            }
+        end
+
         private
             DPR_QUALITY = [75, 50, 35, 23, 20]
 
@@ -226,6 +234,14 @@ module SrcsetTest
             }
         end
 
+        def test_disable_variable_qualities
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, options: { disable_variable_qualities: true })
+
+            srcset.split(',').map { |src|
+                assert(not(src.include? "q="))
+            }
+        end
+
         private
             DPR_QUALITY = [75, 50, 35, 23, 20]
 
@@ -355,10 +371,18 @@ module SrcsetTest
 
         def test_srcset_respects_overriding_quality
             quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:quality_override)
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', q:quality_override)
 
             srcset.split(',').map { |src|
                 assert_includes src, "q=#{quality_override}"
+            }
+        end
+
+        def test_disable_variable_qualities
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', options: { disable_variable_qualities: true })
+
+            srcset.split(',').map { |src|
+                assert(not(src.include? "q="))
             }
         end
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -68,7 +68,26 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_variable_qualities
+            i = 0
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{DPR_QUALITY[i]}"
+                i += 1
+            }
+        end
+
+        def test_srcset_respects_overriding_quality
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:quality_override)
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
+            }
+        end
+
         private
+            DPR_QUALITY = [75, 50, 35, 23, 20]
+
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100)
             end
@@ -156,7 +175,6 @@ module SrcsetTest
     class SrcsetGivenWidthAndHeight < Imgix::Test
         def test_srcset_in_dpr_form
             device_pixel_ratio = 1
-
             srcset.split(',').map { |src|
                 ratio = src.split(' ')[1]
                 assert_equal ("#{device_pixel_ratio}x"), ratio
@@ -191,7 +209,26 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_variable_qualities
+            i = 0
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{DPR_QUALITY[i]}"
+                i += 1
+            }
+        end
+
+        def test_srcset_respects_overriding_quality
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:quality_override)
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
+            }
+        end
+
         private
+            DPR_QUALITY = [75, 50, 35, 23, 20]
+
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100,h:100)
             end
@@ -308,7 +345,26 @@ module SrcsetTest
             }
         end
 
+        def test_srcset_has_variable_qualities
+            i = 0
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{DPR_QUALITY[i]}"
+                i += 1
+            }
+        end
+
+        def test_srcset_respects_overriding_quality
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:quality_override)
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
+            }
+        end
+
         private
+            DPR_QUALITY = [75, 50, 35, 23, 20]
+
             def srcset
                 @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset({h:100,ar:'3:2'})
             end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -85,11 +85,20 @@ module SrcsetTest
             }
         end
 
-        def test_disable_variable_qualities
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, options: { disable_variable_qualities: true })
+        def test_disable_variable_quality
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, options: { disable_variable_quality: true })
 
             srcset.split(',').map { |src|
                 assert(not(src.include? "q="))
+            }
+        end
+
+        def test_respects_quality_param_when_disabled
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:100, options: { disable_variable_quality: true })
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
             }
         end
 
@@ -234,11 +243,20 @@ module SrcsetTest
             }
         end
 
-        def test_disable_variable_qualities
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, options: { disable_variable_qualities: true })
+        def test_disable_variable_quality
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, options: { disable_variable_quality: true })
 
             srcset.split(',').map { |src|
                 assert(not(src.include? "q="))
+            }
+        end
+
+        def test_respects_quality_param_when_disabled
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:100, options: { disable_variable_quality: true })
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
             }
         end
 
@@ -378,11 +396,20 @@ module SrcsetTest
             }
         end
 
-        def test_disable_variable_qualities
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', options: { disable_variable_qualities: true })
+        def test_disable_variable_quality
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', options: { disable_variable_quality: true })
 
             srcset.split(',').map { |src|
                 assert(not(src.include? "q="))
+            }
+        end
+
+        def test_respects_quality_param_when_disabled
+            quality_override = 100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:100, options: { disable_variable_quality: true })
+
+            srcset.split(',').map { |src|
+                assert_includes src, "q=#{quality_override}"
             }
         end
 


### PR DESCRIPTION
This PR automatically appends a `q` parameter mapped to each `dpr` parameter when generating a [fixed-size srcset](https://github.com/imgix/imgix-rb#fixed-image-rendering). This technique is commonly used to compensate for the increased filesize of high-DPR images. Since high-DPR images are displayed at a higher pixel density on devices, image quality can be lowered to reduce overall filesize without sacrificing perceived visual quality. For more information and examples of this technique in action, see [this blog post](https://blog.imgix.com/2016/03/30/dpr-quality).
This behavior will respect any overriding `q` value passed in as a parameter. Additionally, it can be disabled altogether by passing `options: { disable_variable_qualities: true }` to `Imgix:Path#to_srcset`.

The following map of `q` to `dpr` pairs will be generated:

`dpr` | `q`
--- |---
1 | 75 
2 | 50 
3 | 35 
4 | 23 
5 | 20 

This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-rb#fixed-image-rendering) is rendered, for example:

```rb
srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
.path('image.jpg')
.to_srcset(w:100)
```
will generate the following srcset:

```html
https://testing.imgix.net/image.jpg?w=100&dpr=1&q=75 1x,
https://testing.imgix.net/image.jpg?w=100&dpr=2&q=50 2x,
https://testing.imgix.net/image.jpg?w=100&dpr=3&q=35 3x,
https://testing.imgix.net/image.jpg?w=100&dpr=4&q=23 4x,
https://testing.imgix.net/image.jpg?w=100&dpr=5&q=20 5x
```