### PR TITLE
fix: duplicate entries when using min_width or max_width

### DIFF
--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -28,7 +28,7 @@ module Imgix
     resolutions = []
     prev = min || MIN_WIDTH
 
-    while(prev <= max_size)
+    while(prev < max_size)
       # ensures that each width is even
       resolutions.push((2 * (prev / 2).round))
       prev *= 1 + (increment_percentage * 2)

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -694,7 +694,16 @@ module SrcsetTest
 
             assert_operator min, :>=, min_width
             assert_operator max, :<=, max_width
+        end
 
+        def test_max_as_100
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {max_width: 100})
+            assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=100 100w")
+        end
+
+        def test_min_as_8192
+            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: 8192})
+            assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=8192 8192w")
         end
 
         private


### PR DESCRIPTION
This PR fixes an edge case in the `srcset` generation logic.

If the `min_width` option is set to the maximum width possible (8192), then an entry for that width will be generated twice. The same occurs when `max_width` is set to the minimum `srcset` width (100).