### PR TITLE
feat: validate srcset width tolerance

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -101,7 +101,7 @@ module Imgix
       @options = prev_options
       srcset
     end
-    
+
     private
 
     def signature
@@ -133,15 +133,16 @@ module Imgix
 
       widths = options[:widths] || []
       width_tolerance = options[:width_tolerance] ||  DEFAULT_WIDTH_TOLERANCE
-      min_srcset = options[:min_width] || MIN_WIDTH
-      max_srcset = options[:max_width] || MAX_WIDTH
+      min_width = options[:min_width] || MIN_WIDTH
+      max_width = options[:max_width] || MAX_WIDTH
 
       if !widths.empty?
         validate_widths!(widths)
         srcset_widths = widths
-      elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE or min_srcset != MIN_WIDTH or max_srcset != MAX_WIDTH
-        validate_range!(min_srcset, max_srcset)
-        srcset_widths = TARGET_WIDTHS.call(width_tolerance, min_srcset, max_srcset)
+      elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE || min_width != MIN_WIDTH or max_width != MAX_WIDTH
+        validate_range!(min_width, max_width)
+        validate_width_tolerance!(width_tolerance)
+        srcset_widths = TARGET_WIDTHS.call(width_tolerance, min_width, max_width)
       else
         srcset_widths = @target_widths
       end
@@ -176,13 +177,19 @@ module Imgix
       srcset[0..-3]
     end
 
+    def validate_width_tolerance!(width_tolerance)
+      if !width_tolerance.is_a?(Numeric) || !width_tolerance.positive?
+        raise ArgumentError, "The srcset widthTolerance argument can only be passed a positive scalar number"
+      end
+    end
+
     def validate_widths!(widths)
       unless widths.is_a? Array
         raise ArgumentError, "The widths argument must be passed a valid array of integers"
       else
         positive_integers = widths.all? {|i| i.is_a?(Integer) and i > 0}
         unless positive_integers
-          raise ArgumentError, "A custom widths array must only contain positive integer values"  
+          raise ArgumentError, "A custom widths array must only contain positive integer values"
         end
       end
     end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -139,7 +139,7 @@ module Imgix
       if !widths.empty?
         validate_widths!(widths)
         srcset_widths = widths
-      elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE || min_width != MIN_WIDTH or max_width != MAX_WIDTH
+      elsif width_tolerance != DEFAULT_WIDTH_TOLERANCE || min_width != MIN_WIDTH || max_width != MAX_WIDTH
         validate_range!(min_width, max_width)
         validate_width_tolerance!(width_tolerance)
         srcset_widths = TARGET_WIDTHS.call(width_tolerance, min_width, max_width)

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -178,7 +178,7 @@ module Imgix
     end
 
     def validate_width_tolerance!(width_tolerance)
-      if !width_tolerance.is_a?(Numeric) || !width_tolerance.positive?
+      if !width_tolerance.is_a?(Numeric) || width_tolerance <= 0
         raise ArgumentError, "The srcset widthTolerance argument can only be passed a positive scalar number"
       end
     end


### PR DESCRIPTION
This PR seeks to prepare `build_srcset_pairs` to cache srcset widths in
accordance with (i.a.w.) the implementation here: [imgix-core-js](https://github.com/imgix/imgix-core-js/blob/6aa0b613794bed1cbaeeaf6a7157dde00b9127f0/dist/imgix-core-js.js#L173).

In convention with the codebase, `validate_width_tolerance` is private.
In convention with the codebase, it is also tested indirectly when
testing the behavior and output of srcset generation.

Let me know if you want a new test for this @sherwinski. I saw the
width-tolerance integration tests you've written, if you feel like
they're sufficient to indirectly test the behavior of this function
then no additional test is needed at this time.

This commit also refactors variable names at the call site,`build_src_pairs`.
It changes `max_srcset` to `max_width` to denote the intent is to store a max
width and not a max srcset.

`or` has been exchanged for `||` i.a.w. rubocop rules.

The change made to line 192––trailing whitespace removed––was not entirely
intentional, but desirable.