### PR TITLE
refactor(client.rb): improve rubocop compliance

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -29,7 +29,8 @@ module Imgix
     end
 
     def purge(path)
-      raise 'Authentication token required' if @api_key.nil?
+      token_error = 'Authentication token required'
+      raise token_error if @api_key.nil?
 
       url = prefix(path) + path
       uri = URI.parse('https://api.imgix.com/v2/image/purger')


### PR DESCRIPTION
This commit refactors `client.rb` to improve rubocop compliance. This
will be an ongoing process; this commit does not seek full compliance
with rubocop, nor should it.

The biggest change in this commit is `freeze`-ing `DEFAULTS`. This hash
is meant to be a constant. This change enforces the ALL_CAPS semantics
of constants such that modifying this value will result in a `FrozenError`:

```ruby
irb(main):001:0> H = {a: 1}.freeze
=> {:a=>1}
irb(main):002:0> H[:a] = 2
Traceback (most recent call last):
        4: from /Users/Eric/.rbenv/versions/2.6.3/bin/irb:23:in `<main>'
        3: from /Users/Eric/.rbenv/versions/2.6.3/bin/irb:23:in `load'
        2: from
/Users/Eric/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/gems/irb-1.0.0/exe/irb:11:in
`<top (required)>'
        1: from (irb):2
FrozenError (can't modify frozen Hash)
```

Double quoted strings have been exchanged for single quoted strings
(except for where interpolation is used).

Error messages have been refactored to:
- reduce their line length
- prepare for unified error messaging

Why? Consider these assignments to be placeholders. This way we can
talk about whether something should be called a `host_error` or a
`domain_error` and get a feel for it while preparing to unify error
messaging under an `ImgixError` or `Error` module. Once we have
settled on the details, the new error values can be swapped out
without ambiguity. Unifying error messaging this way will pull
most of the strings out of this file.

**Todo**:
- line 27, `ixlib` cannot be found
- line 52, `path` is never used
  - it is used and passed an argument in tests, though it doesn't get
used
  - this could be refactored out in the next pass
- lines 32 thru 50 will need another pass and a dedicated PR

 **Please** let me know if you want more context, agree-with/like
the changes, etc.

- [x] all tests pass