### PR TITLE
refactor: dry up test suite, keep same function

### DIFF
--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -1,716 +1,756 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 module SrcsetTest
+  RESOLUTIONS = [
+    100, 116, 134, 156, 182, 210, 244,
+    282, 328, 380, 442, 512, 594, 688,
+    798, 926, 1074, 1246, 1446, 1678, 1946,
+    2258, 2618, 3038, 3524, 4088, 4742, 5500,
+    6380, 7400, 8192
+  ].freeze
 
-    class SrcsetDefault < Imgix::Test
-        def test_no_parameters
-            srcset = path.to_srcset()
-            expected_number_of_pairs = 31
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+  DPR_QUALITY = [75, 50, 35, 23, 20].freeze
 
-        def test_srcset_pair_values
-            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
-            srcset = path.to_srcset()
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
+  DOMAIN = 'testing.imgix.net'
+  TOKEN = 'MYT0KEN'
+  JPG_PATH = 'image.jpg'
 
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
+  def mock_client
+    Imgix::Client.new(
+      host: DOMAIN,
+      include_library_param: false
+    ).path(JPG_PATH)
+  end
 
-        private
-            def path
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg')
-            end
+  def mock_signed_client
+    Imgix::Client.new(
+      host: DOMAIN,
+      secure_url_token: TOKEN,
+      include_library_param: false
+    ).path(JPG_PATH)
+  end
+
+  def signature_base(params)
+    TOKEN + '/' + JPG_PATH + params
+  end
+
+  def get_sig_from(src)
+    src.slice(src.index('s=') + 2, src.length)
+  end
+
+  def get_params_from(src)
+    src[src.index('?')..src.index('s=') - 2]
+  end
+
+  def get_expected_signature(src)
+    # Ensure signature param exists.
+    assert_includes src, 's='
+
+    params = get_params_from(src)
+    signature_base = signature_base(params)
+
+    Digest::MD5.hexdigest(signature_base)
+  end
+
+  class SrcsetDefault < Imgix::Test
+    include SrcsetTest
+
+    def test_no_parameters
+      srcset = path.to_srcset
+
+      expected_number_of_pairs = 31
+      assert_equal expected_number_of_pairs, srcset.split(',').length
     end
 
-    class SrcsetGivenWidth < Imgix::Test
-        def test_srcset_in_dpr_form
-            device_pixel_ratio = 1
+    def test_srcset_pair_values
+      resolutions = RESOLUTIONS
+      srcset = path.to_srcset
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
 
-            srcset.split(',').map { |src|
-                ratio = src.split(' ')[1]
-                assert_equal ("#{device_pixel_ratio}x"), ratio
-                device_pixel_ratio += 1
-            }
-        end
-
-        def test_srcset_has_dpr_params
-            i = 1
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, "dpr=#{i}"
-                i += 1
-            }
-        end
-
-        def test_srcset_signs_urls
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, 's='
-
-                # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=') - 2]
-
-                # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=') + 2, src.length)
-
-                signature_base = 'MYT0KEN' + '/image.jpg' + params;
-                expected_signature = Digest::MD5.hexdigest(signature_base)
-                
-                assert_equal expected_signature, generated_signature
-            }
-        end
-
-        def test_srcset_has_variable_qualities
-            i = 0
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{DPR_QUALITY[i]}"
-                i += 1
-            }
-        end
-
-        def test_srcset_respects_overriding_quality
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:quality_override)
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        def test_disable_variable_quality
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert(not(src.include? "q="))
-            }
-        end
-
-        def test_respects_quality_param_when_disabled
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, q:100, options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        private
-            DPR_QUALITY = [75, 50, 35, 23, 20]
-
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100)
-            end
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], resolutions[i])
+      end
     end
 
-    class SrcsetGivenHeight < Imgix::Test
-        def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 31
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+    private
 
-        def test_srcset_pair_values
-            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
+    def path
+      @client ||= mock_signed_client
+    end
+  end
 
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
+  class SrcsetGivenWidth < Imgix::Test
+    include SrcsetTest
 
-        def test_srcset_respects_height_parameter
-            srcset.split(',').map { |src|
-                assert_includes src, 'h='
-            }
-        end
+    def test_srcset_in_dpr_form
+      device_pixel_ratio = 1
 
-        def test_srcset_within_bounds
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, 100
-            assert_operator max, :<=, 8192
-        end
-
-        # a 17% testing threshold is used to account for rounding
-        def test_srcset_iterates_17_percent
-            increment_allowed = 0.17
-
-            # create an array of widths
-            widths = srcset.split(',').map { |src|
-                src.split(' ')[1].to_i
-            }
-
-            prev = widths[0]
-
-            for i in 1..widths.length - 1 do
-                element = widths[i]
-                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
-                prev = element
-            end
-        end
-
-        def test_srcset_signs_urls
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, 's='
-
-                # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=') - 2]
-
-                # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=') + 2, src.length)
-
-                signature_base = 'MYT0KEN' + '/image.jpg' + params;
-                expected_signature = Digest::MD5.hexdigest(signature_base)
-                
-                assert_equal expected_signature, generated_signature
-            }
-        end
-
-        private
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(h:100)
-            end
+      srcset.split(',').map do |src|
+        ratio = src.split(' ')[1]
+        assert_equal "#{device_pixel_ratio}x", ratio
+        device_pixel_ratio += 1
+      end
     end
 
-    class SrcsetGivenWidthAndHeight < Imgix::Test
-        def test_srcset_in_dpr_form
-            device_pixel_ratio = 1
-            srcset.split(',').map { |src|
-                ratio = src.split(' ')[1]
-                assert_equal ("#{device_pixel_ratio}x"), ratio
-                device_pixel_ratio += 1
-            }
-        end
-
-        def test_srcset_has_dpr_params
-            i = 1
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, "dpr=#{i}"
-                i += 1
-            }
-        end
-
-        def test_srcset_signs_urls
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, 's='
-
-                # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=') - 2]
-
-                # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=') + 2, src.length)
-
-                signature_base = 'MYT0KEN' + '/image.jpg' + params;
-                expected_signature = Digest::MD5.hexdigest(signature_base)
-
-                assert_equal expected_signature, generated_signature
-            }
-        end
-
-        def test_srcset_has_variable_qualities
-            i = 0
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{DPR_QUALITY[i]}"
-                i += 1
-            }
-        end
-
-        def test_srcset_respects_overriding_quality
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:quality_override)
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        def test_disable_variable_quality
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert(not(src.include? "q="))
-            }
-        end
-
-        def test_respects_quality_param_when_disabled
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:100, options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        private
-            DPR_QUALITY = [75, 50, 35, 23, 20]
-
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100,h:100)
-            end
+    def test_srcset_has_dpr_params
+      i = 1
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        assert_includes src, "dpr=#{i}"
+        i += 1
+      end
     end
 
-    class SrcsetGivenAspectRatio < Imgix::Test
-        def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 31
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+    def test_srcset_signs_urls
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        expected_signature = get_expected_signature(src)
 
-        def test_srcset_pair_values
-            resolutions = [100, 116, 134, 156, 182, 210, 244, 282,
-                328, 380, 442, 512, 594, 688, 798, 926,
-                1074, 1246, 1446, 1678, 1946, 2258, 2618,
-                3038, 3524, 4088, 4742, 5500, 6380, 7400, 8192]
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
-
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
-
-        def test_srcset_within_bounds
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, 100
-            assert_operator max, :<=, 8192
-        end
-
-        # a 17% testing threshold is used to account for rounding
-        def test_srcset_iterates_17_percent
-            increment_allowed = 0.17
-
-            # create an array of widths
-            widths = srcset.split(',').map { |src|
-                src.split(' ')[1].to_i
-            }
-
-            prev = widths[0]
-
-            for i in 1..widths.length - 1 do
-                element = widths[i]
-                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
-                prev = element
-            end
-        end
-
-        def test_srcset_signs_urls
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, 's='
-
-                # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=') - 2]
-
-                # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=') + 2, src.length)
-
-                signature_base = 'MYT0KEN' + '/image.jpg' + params;
-                expected_signature = Digest::MD5.hexdigest(signature_base)
-                
-                assert_equal expected_signature, generated_signature
-            }
-        end
-
-        private
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(ar:'3:2')
-            end
+        assert_includes src, expected_signature
+      end
     end
 
-    class SrcsetGivenAspectRatioAndHeight < Imgix::Test
-        def test_srcset_in_dpr_form
-            device_pixel_ratio = 1
-
-            srcset.split(',').map { |src|
-                ratio = src.split(' ')[1]
-                assert_equal ("#{device_pixel_ratio}x"), ratio
-                device_pixel_ratio += 1
-            }
-        end
-
-        def test_srcset_has_dpr_params
-            i = 1
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, "dpr=#{i}"
-                i += 1
-            }
-        end
-
-        def test_srcset_signs_urls
-            srcset.split(',').map { |srcset_split|
-                src = srcset_split.split(' ')[0]
-                assert_includes src, 's='
-
-                # parses out all parameters except for 's=...'
-                params = src[src.index('?')..src.index('s=') - 2]
-
-                # parses out the 's=...' parameter
-                generated_signature = src.slice(src.index('s=') + 2, src.length)
-
-                signature_base = 'MYT0KEN' + '/image.jpg' + params;
-                expected_signature = Digest::MD5.hexdigest(signature_base)
-
-                assert_equal expected_signature, generated_signature
-            }
-        end
-
-        def test_srcset_has_variable_qualities
-            i = 0
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{DPR_QUALITY[i]}"
-                i += 1
-            }
-        end
-
-        def test_srcset_respects_overriding_quality
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', q:quality_override)
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        def test_disable_variable_quality
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, ar:'3:2', options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert(not(src.include? "q="))
-            }
-        end
-
-        def test_respects_quality_param_when_disabled
-            quality_override = 100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(w:100, h:100, q:100, options: { disable_variable_quality: true })
-
-            srcset.split(',').map { |src|
-                assert_includes src, "q=#{quality_override}"
-            }
-        end
-
-        private
-            DPR_QUALITY = [75, 50, 35, 23, 20]
-
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset({h:100,ar:'3:2'})
-            end
+    def test_srcset_has_variable_qualities
+      i = 0
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{DPR_QUALITY[i]}"
+        i += 1
+      end
     end
 
-    class SrcsetWidthTolerance < Imgix::Test
-        def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 15
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+    def test_srcset_respects_overriding_quality
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(w: 100, q: quality_override)
 
-        def test_srcset_pair_values
-            resolutions = [100,140,196,274,384,538,752,1054,1476,2066,2892,4050,5670,7938,8192]
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
-
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
-
-        def test_srcset_within_bounds
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-            assert_operator min, :>=, 100
-            assert_operator max, :<=, 8192
-        end
-
-        # a 41% testing threshold is used to account for rounding
-        def test_srcset_iterates_41_percent
-            increment_allowed = 0.41
-
-            # create an array of widths
-            widths = srcset.split(',').map { |src|
-                src.split(' ')[1].to_i
-            }
-
-            prev = widths[0]
-
-            for i in 1..widths.length - 1 do
-                element = widths[i]
-                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
-                prev = element
-            end
-        end
-
-        def test_invalid_tolerance_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {width_tolerance: 'abc'})
-            }
-        end
-
-        def test_negative_tolerance_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {width_tolerance: -0.10})
-            }
-        end
-
-        def test_with_param_after
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(options: {width_tolerance: 0.20}, h:1000, fit:"clip")
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "width_tolerance="))
-        end
-
-        def test_with_param_before
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", options: {width_tolerance: 0.20})
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "width_tolerance="))
-        end
-
-        private
-            def srcset
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(options: {width_tolerance: 0.20})
-            end
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
     end
 
-    class SrcsetCustomWidths < Imgix::Test
-        def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 4
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+    def test_disable_variable_quality
+      srcset = mock_signed_client.to_srcset(
+        w: 100,
+        options: { disable_variable_quality: true }
+      )
 
-        def test_srcset_pair_values
-            resolutions = [100, 500, 1000, 1800]
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
-
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
-
-        def test_srcset_within_bounds
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, @widths[0]
-            assert_operator max, :<=, @widths[-1]
-        end
-
-        def test_invalid_widths_input_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {widths: 'abc'})
-            }
-        end
-
-        def test_non_integer_array_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {widths: [100, 200, false]})
-            }
-        end
-
-        def test_negative_integer_array_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {widths: [100, 200, -100]})
-            }
-        end
-
-        def test_with_param_after
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(options: {widths: [100, 200, 300]}, h:1000, fit:"clip")
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "widths="))
-        end
-
-        def test_with_param_before
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", options: {widths: [100, 200, 300]})
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "widths="))
-        end
-
-        private
-            def srcset
-                @widths = [100, 500, 1000, 1800]
-                @client ||= Imgix::Client.new(
-                    host: 'testing.imgix.net',
-                    include_library_param: false)
-                    .path('image.jpg')
-                    .to_srcset(options: {widths: @widths})
-            end
+      srcset.split(',').map do |src|
+        assert(not(src.include?('q=')))
+      end
     end
 
-    class SrcsetMinMaxWidths < Imgix::Test
-        def test_srcset_generates_width_pairs
-            expected_number_of_pairs = 11
-            assert_equal expected_number_of_pairs, srcset.split(',').length
-        end
+    def test_respects_quality_param_when_disabled
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(
+        w: 100, q: 100,
+        options: { disable_variable_quality: true }
+      )
 
-        def test_srcset_pair_values
-            resolutions = [500,580,672,780,906,1050,1218,1414,1640,1902,2000]
-            srclist = srcset.split(',').map { |srcset_split|
-                srcset_split.split(' ')[1].to_i
-            }
-
-            for i in 0..srclist.length - 1 do
-                assert_equal(srclist[i], resolutions[i])
-            end
-        end
-
-        def test_srcset_within_bounds
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, @MIN
-            assert_operator max, :<=, @MAX
-        end
-
-        # a 41% testing threshold is used to account for rounding
-        def test_with_custom_width_tolerance
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: 500, max_width: 2000, width_tolerance: 0.20})
-
-            increment_allowed = 0.41
-
-            # create an array of widths
-            widths = srcset.split(',').map { |src|
-                src.split(' ')[1].to_i
-            }
-
-            prev = widths[0]
-
-            for i in 1..widths.length - 1 do
-                element = widths[i]
-                assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
-                prev = element
-            end
-        end
-
-        def test_invalid_min_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {min_width: 'abc'})
-            }
-        end
-
-        def test_negative_max_emits_error
-            assert_raises(ArgumentError) {
-                Imgix::Client.new(host: 'testing.imgix.net')
-                .path('image.jpg')
-                .to_srcset(options: {max_width: -100})
-            }
-        end
-
-        def test_with_param_after
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(options: {min_width: 500, max_width:2000}, h:1000, fit:"clip")
-
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_width="))
-            assert(not(srcset.include? "max_width="))
-        end
-
-        def test_with_param_before
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
-            .path('image.jpg')
-            .to_srcset(h:1000, fit:"clip", options: {min_width: 500, max_width:2000})
-
-            assert_includes(srcset, "h=")
-            assert(not(srcset.include? "min_width="))
-            assert(not(srcset.include? "max_width="))
-        end
-
-        def test_only_min
-            min_width = 1000
-            max_width = 8192
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: min_width})
-
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, min_width
-            assert_operator max, :<=, max_width
-        end
-
-        def test_only_max
-            min_width = 100
-            max_width = 1000
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {max_width: max_width})
-            min, *max = srcset.split(',')
-
-            # parse out the width descriptor as an integer
-            min = min.split(' ')[1].to_i
-            max = max[max.length - 1].split(' ')[1].to_i
-
-            assert_operator min, :>=, min_width
-            assert_operator max, :<=, max_width
-        end
-
-        def test_max_as_100
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {max_width: 100})
-            assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=100 100w")
-        end
-
-        def test_min_as_8192
-            srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: 8192})
-            assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=8192 8192w")
-        end
-
-        private
-            def srcset
-                @MIN = 500
-                @MAX = 2000
-                @client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false).path('image.jpg').to_srcset(options: {min_width: @MIN, max_width: @MAX})
-            end
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
     end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset(w: 100)
+    end
+  end
+
+  class SrcsetGivenHeight < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_generates_width_pairs
+      expected_number_of_pairs = 31
+      assert_equal expected_number_of_pairs, srcset.split(',').length
+    end
+
+    def test_srcset_pair_values
+      resolutions = RESOLUTIONS
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
+
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], resolutions[i])
+      end
+    end
+
+    def test_srcset_respects_height_parameter
+      srcset.split(',').map do |src|
+        assert_includes src, 'h='
+      end
+    end
+
+    def test_srcset_within_bounds
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, 100
+      assert_operator max, :<=, 8192
+    end
+
+    # a 17% testing threshold is used to account for rounding
+    def test_srcset_iterates_17_percent
+      increment_allowed = 0.17
+
+      # create an array of widths
+      widths = srcset.split(',').map do |src|
+        src.split(' ')[1].to_i
+      end
+
+      prev = widths[0]
+
+      for i in 1..widths.length - 1
+        element = widths[i]
+        assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
+        prev = element
+      end
+    end
+
+    def test_srcset_signs_urls
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        expected_signature = get_expected_signature(src)
+
+        assert_includes src, expected_signature
+      end
+    end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset(h: 100)
+    end
+  end
+
+  class SrcsetGivenWidthAndHeight < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_in_dpr_form
+      device_pixel_ratio = 1
+      srcset.split(',').map do |src|
+        ratio = src.split(' ')[1]
+        assert_equal "#{device_pixel_ratio}x", ratio
+        device_pixel_ratio += 1
+      end
+    end
+
+    def test_srcset_has_dpr_params
+      i = 1
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        assert_includes src, "dpr=#{i}"
+        i += 1
+      end
+    end
+
+    def test_srcset_signs_urls
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        expected_signature = get_expected_signature(src)
+
+        assert_includes src, expected_signature
+      end
+    end
+
+    def test_srcset_has_variable_qualities
+      i = 0
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{DPR_QUALITY[i]}"
+        i += 1
+      end
+    end
+
+    def test_srcset_respects_overriding_quality
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(w: 100, h: 100, q: quality_override)
+
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
+    end
+
+    def test_disable_variable_quality
+      srcset = mock_signed_client.to_srcset(
+        w: 100, h: 100,
+        options: { disable_variable_quality: true }
+      )
+
+      srcset.split(',').map do |src|
+        assert(not(src.include?('q=')))
+      end
+    end
+
+    def test_respects_quality_param_when_disabled
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(
+        w: 100, h: 100, q: 100,
+        options: { disable_variable_quality: true }
+      )
+
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
+    end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset(w: 100, h: 100)
+    end
+  end
+
+  class SrcsetGivenAspectRatio < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_generates_width_pairs
+      expected_number_of_pairs = 31
+      assert_equal expected_number_of_pairs, srcset.split(',').length
+    end
+
+    def test_srcset_pair_values
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
+
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], RESOLUTIONS[i])
+      end
+    end
+
+    def test_srcset_within_bounds
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, 100
+      assert_operator max, :<=, 8192
+    end
+
+    # a 17% testing threshold is used to account for rounding
+    def test_srcset_iterates_17_percent
+      increment_allowed = 0.17
+
+      # create an array of widths
+      widths = srcset.split(',').map do |src|
+        src.split(' ')[1].to_i
+      end
+
+      prev = widths[0]
+
+      for i in 1..widths.length - 1
+        element = widths[i]
+        assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
+        prev = element
+      end
+    end
+
+    def test_srcset_signs_urls
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        expected_signature = get_expected_signature(src)
+
+        assert_includes src, expected_signature
+      end
+    end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset(ar: '3:2')
+    end
+  end
+
+  class SrcsetGivenAspectRatioAndHeight < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_in_dpr_form
+      device_pixel_ratio = 1
+
+      srcset.split(',').map do |src|
+        ratio = src.split(' ')[1]
+        assert_equal "#{device_pixel_ratio}x", ratio
+        device_pixel_ratio += 1
+      end
+    end
+
+    def test_srcset_has_dpr_params
+      i = 1
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        assert_includes src, "dpr=#{i}"
+        i += 1
+      end
+    end
+
+    def test_srcset_signs_urls
+      srcset.split(',').map do |srcset_split|
+        src = srcset_split.split(' ')[0]
+        expected_signature = get_expected_signature(src)
+
+        assert_includes src, expected_signature
+      end
+    end
+
+    def test_srcset_has_variable_qualities
+      i = 0
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{DPR_QUALITY[i]}"
+        i += 1
+      end
+    end
+
+    def test_srcset_respects_overriding_quality
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(
+        w: 100, ar: '3:2', q: quality_override
+      )
+
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
+    end
+
+    def test_disable_variable_quality
+      srcset = mock_signed_client.to_srcset(
+        w: 100, ar: '3:2',
+        options: { disable_variable_quality: true }
+      )
+
+      srcset.split(',').map do |src|
+        assert(not(src.include?('q=')))
+      end
+    end
+
+    def test_respects_quality_param_when_disabled
+      quality_override = 100
+      srcset = mock_signed_client.to_srcset(
+        w: 100, h: 100, q: 100,
+        options: { disable_variable_quality: true }
+      )
+
+      srcset.split(',').map do |src|
+        assert_includes src, "q=#{quality_override}"
+      end
+    end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset({ h: 100, ar: '3:2' })
+    end
+  end
+
+  class SrcsetWidthTolerance < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_generates_width_pairs
+      expected_number_of_pairs = 15
+      assert_equal expected_number_of_pairs, srcset.split(',').length
+    end
+
+    def test_srcset_pair_values
+      resolutions = [100, 140, 196, 274, 384,
+                     538, 752, 1054, 1476, 2066,
+                     2892, 4050, 5670, 7938, 8192]
+
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
+
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], resolutions[i])
+      end
+    end
+
+    def test_srcset_within_bounds
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+      assert_operator min, :>=, 100
+      assert_operator max, :<=, 8192
+    end
+
+    # a 41% testing threshold is used to account for rounding
+    def test_srcset_iterates_41_percent
+      increment_allowed = 0.41
+
+      # create an array of widths
+      widths = srcset.split(',').map do |src|
+        src.split(' ')[1].to_i
+      end
+
+      prev = widths[0]
+
+      for i in 1..widths.length - 1
+        element = widths[i]
+        assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
+        prev = element
+      end
+    end
+
+    def test_invalid_tolerance_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { width_tolerance: 'abc' })
+      end
+    end
+
+    def test_negative_tolerance_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { width_tolerance: -0.10 })
+      end
+    end
+
+    def test_with_param_after
+      srcset = mock_signed_client.to_srcset(
+        options: { width_tolerance: 0.20 },
+        h: 1000, fit: 'clip'
+      )
+
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('width_tolerance=')))
+    end
+
+    def test_with_param_before
+      srcset = mock_signed_client.to_srcset(
+        h: 1000, fit: 'clip',
+        options: { width_tolerance: 0.20 }
+      )
+
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('width_tolerance=')))
+    end
+
+    private
+
+    def srcset
+      @client ||= mock_signed_client.to_srcset(
+        options: { width_tolerance: 0.20 }
+      )
+    end
+  end
+
+  class SrcsetCustomWidths < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_generates_width_pairs
+      expected_number_of_pairs = 4
+      assert_equal expected_number_of_pairs, srcset.split(',').length
+    end
+
+    def test_srcset_pair_values
+      resolutions = [100, 500, 1000, 1800]
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
+
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], resolutions[i])
+      end
+    end
+
+    def test_srcset_within_bounds
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, @widths[0]
+      assert_operator max, :<=, @widths[-1]
+    end
+
+    def test_invalid_widths_input_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { widths: 'abc' })
+      end
+    end
+
+    def test_non_integer_array_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { widths: [100, 200, false] })
+      end
+    end
+
+    def test_negative_integer_array_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { widths: [100, 200, -100] })
+      end
+    end
+
+    def test_with_param_after
+      srcset = mock_signed_client.to_srcset(
+        options: { widths: [100, 200, 300] },
+        h: 1000, fit: 'clip'
+      )
+
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('widths=')))
+    end
+
+    def test_with_param_before
+      srcset = mock_client.to_srcset(
+        h: 1000, fit: 'clip',
+        options: { widths: [100, 200, 300] }
+      )
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('widths=')))
+    end
+
+    private
+
+    def srcset
+      @widths = [100, 500, 1000, 1800]
+      @client ||= mock_signed_client.to_srcset(options: { widths: @widths })
+    end
+  end
+
+  class SrcsetMinMaxWidths < Imgix::Test
+    include SrcsetTest
+
+    def test_srcset_generates_width_pairs
+      expected_number_of_pairs = 11
+      assert_equal expected_number_of_pairs, srcset.split(',').length
+    end
+
+    def test_srcset_pair_values
+      resolutions = [500, 580, 672, 780, 906, 1050,
+        1218, 1414, 1640, 1902, 2000]
+      srclist = srcset.split(',').map do |srcset_split|
+        srcset_split.split(' ')[1].to_i
+      end
+
+      for i in 0..srclist.length - 1
+        assert_equal(srclist[i], resolutions[i])
+      end
+    end
+
+    def test_srcset_within_bounds
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, @MIN
+      assert_operator max, :<=, @MAX
+    end
+
+    # a 41% testing threshold is used to account for rounding
+    def test_with_custom_width_tolerance
+      srcset = mock_client.to_srcset(
+        options: { min_width: 500, max_width: 2000, width_tolerance: 0.20 }
+      )
+
+      increment_allowed = 0.41
+
+      # create an array of widths
+      widths = srcset.split(',').map do |src|
+        src.split(' ')[1].to_i
+      end
+
+      prev = widths[0]
+
+      for i in 1..widths.length - 1
+        element = widths[i]
+        assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
+        prev = element
+      end
+    end
+
+    def test_invalid_min_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { min_width: 'abc' })
+      end
+    end
+
+    def test_negative_max_emits_error
+      assert_raises(ArgumentError) do
+        mock_client.to_srcset(options: { max_width: -100 })
+      end
+    end
+
+    def test_with_param_after
+      srcset = mock_client.to_srcset(
+        options: { min_width: 500, max_width: 2000 },
+        h: 1000, fit: 'clip'
+      )
+
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('min_width=')))
+      assert(not(srcset.include?('max_width=')))
+    end
+
+    def test_with_param_before
+      srcset = mock_client.to_srcset(
+        h: 1000, fit: 'clip',
+        options: { min_width: 500, max_width: 2000 }
+      )
+
+      assert_includes(srcset, 'h=')
+      assert(not(srcset.include?('min_width=')))
+      assert(not(srcset.include?('max_width=')))
+    end
+
+    def test_only_min
+      min_width = 1000
+      max_width = 8192
+      srcset = mock_client.to_srcset(options: { min_width: min_width })
+
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, min_width
+      assert_operator max, :<=, max_width
+    end
+
+    def test_only_max
+      min_width = 100
+      max_width = 1000
+      srcset = mock_client.to_srcset(options: { max_width: max_width })
+      min, *max = srcset.split(',')
+
+      # parse out the width descriptor as an integer
+      min = min.split(' ')[1].to_i
+      max = max[max.length - 1].split(' ')[1].to_i
+
+      assert_operator min, :>=, min_width
+      assert_operator max, :<=, max_width
+    end
+
+    def test_max_as_100
+      srcset = mock_client.to_srcset(options: { max_width: 100 })
+      assert_equal(srcset, 'https://testing.imgix.net/image.jpg?w=100 100w')
+    end
+
+    def test_min_as_8192
+      srcset = mock_client.to_srcset(options: { min_width: 8192 })
+      assert_equal(srcset, 'https://testing.imgix.net/image.jpg?w=8192 8192w')
+    end
+
+    private
+
+    def srcset
+      @MIN = 500
+      @MAX = 2000
+      @client ||= mock_client.to_srcset(
+        options: { min_width: @MIN, max_width: @MAX }
+      )
+    end
+  end
 end


### PR DESCRIPTION
This PR seeks to DRY up `srcset_test.rb`. The general idea is to DRY
the test suites up  for:

* pattern ergonomics
* correctness
* (possibly) introducing [RSpec](https://rspec.info)

**Commonly used functionality and constants** have been pulled up into
the `SrcsetTest` module.

* `mock_client` appears 17 times
* `mock_signed_client` appears 21 times
* `get_expected_signature` appears 6 times
  * this function composes the previous method into 3 functions:
    * `get_sig_from(src)`
    * `get_params_from(src)`
    * and finally returns the result of the MD5 operation
* `RESOLUTIONS` and `DPR_QUALITY` are now module-level, frozen,
  constants

This PR also complies with many RuboCop suggestions (but not all).

The suggestions I elected to commit are mostly to:
* improve readability
  * corral line lengths
  * use single-quoted strings (where interpolation is not needed)
  * align chained calls (which there are fewer of now)
  * use consistent indentation
* seek idiomatic code

**Note:** Due to the formatting (whitespace) changes, the diff isn't as
helpful as it should be here. I can split this commit in two.