### PR TITLE
fix: remove ensure even requirement

### DIFF
--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -32,7 +32,7 @@ module Imgix
 
     while prev < max_size
       # ensures that each width is even
-      resolutions.push((2 * (prev / 2).round))
+      resolutions.push(prev.round)
       prev *= 1 + (increment_percentage * 2)
     end
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -4,11 +4,10 @@ require 'test_helper'
 
 module SrcsetTest
   RESOLUTIONS = [
-    100, 116, 134, 156, 182, 210, 244,
-    282, 328, 380, 442, 512, 594, 688,
-    798, 926, 1074, 1246, 1446, 1678, 1946,
-    2258, 2618, 3038, 3524, 4088, 4742, 5500,
-    6380, 7400, 8192
+    100, 116, 135, 156, 181, 210, 244, 283,
+    328, 380, 441, 512, 594, 689, 799, 927,
+    1075, 1247, 1446, 1678, 1946, 2257, 2619,
+    3038, 3524, 4087, 4741, 5500, 6380, 7401, 8192
   ].freeze
 
   DPR_QUALITY = [75, 50, 35, 23, 20].freeze
@@ -461,8 +460,8 @@ module SrcsetTest
 
     def test_srcset_pair_values
       resolutions = [100, 140, 196, 274, 384,
-                     538, 752, 1054, 1476, 2066,
-                     2892, 4050, 5670, 7938, 8192]
+                     538, 753, 1054, 1476, 2066,
+                     2893, 4050, 5669, 7937, 8192]
 
       srclist = srcset.split(',').map do |srcset_split|
         srcset_split.split(' ')[1].to_i
@@ -626,8 +625,8 @@ module SrcsetTest
     end
 
     def test_srcset_pair_values
-      resolutions = [500, 580, 672, 780, 906, 1050,
-        1218, 1414, 1640, 1902, 2000]
+      resolutions = [500, 580, 673, 780, 905, 1050,
+        1218, 1413, 1639, 1901, 2000]
       srclist = srcset.split(',').map do |srcset_split|
         srcset_split.split(' ')[1].to_i
       end


### PR DESCRIPTION
This PR removes the `ensure even` requirement on target widths and
updates the appropriate tests.

Previously, image target widths were required to be even integer values.
The original line of thought accounted for physical device pixel dimension
evenness; however, this is important only if images are rendered at full
viewport width.

Since this is not always the case, we wanted to include both odd and even
values here to give users more flexibility and to better meet user expectations:
i.e. if widths [115, …, 2121] were requested, then [116, …, 2122] could be
considered unexpected.