### PR TITLE
chore: change refs of master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 `imgix-rb` is a client library for generating image URLs with [imgix](https://www.imgix.com/). It is tested under Ruby versions `2.3.0`, `2.2.4`, `2.1.8`, `jruby-9.0.5.0`, and `rbx-3.107`.
 
 [![Gem Version](https://img.shields.io/gem/v/imgix.svg)](https://rubygems.org/gems/imgix)
-[![Build Status](https://travis-ci.org/imgix/imgix-rb.svg?branch=master)](https://travis-ci.org/imgix/imgix-rb)
+[![Build Status](https://travis-ci.org/imgix/imgix-rb.svg?branch=main)](https://travis-ci.org/imgix/imgix-rb)
 ![Downloads](https://img.shields.io/gem/dt/imgix)
-[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/imgix/imgix-rb/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat)](https://github.com/imgix/imgix-rb/blob/main/LICENSE)
 
 ---
 <!-- /ix-docs-ignore -->

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata = {
     'bug_tracker_uri'   => 'https://github.com/imgix/imgix-rb/issues',
-    'changelog_uri'     => 'https://github.com/imgix/imgix-rb/blob/master/CHANGELOG.md',
+    'changelog_uri'     => 'https://github.com/imgix/imgix-rb/blob/main/CHANGELOG.md',
     'documentation_uri' => "https://www.rubydoc.info/gems/imgix/#{spec.version}",
     'source_code_uri'   => "https://github.com/imgix/imgix-rb/tree/#{spec.version}"
   }


### PR DESCRIPTION
This PR changes any references from the master branch to the main branch, now that it is the default.