### PR TITLE
fix: deprecate ParamHelpers.rect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.3.0
   - 2.2.4
   - 2.1.8
-  - jruby-9.0.5.0
+  - jruby-9.2.11.0
 
 jobs:
   # Use `fast_finish`, don't wait for any allowed failures.

--- a/lib/imgix/param_helpers.rb
+++ b/lib/imgix/param_helpers.rb
@@ -3,6 +3,7 @@
 module Imgix
   module ParamHelpers
     def rect(position)
+      warn "Warning: `ParamHelpers.rect` has been deprecated and will be removed in the next major version."
       @options[:rect] = position and return self if position.is_a?(String)
 
       @options[:rect] = [

--- a/lib/imgix/param_helpers.rb
+++ b/lib/imgix/param_helpers.rb
@@ -3,7 +3,7 @@
 module Imgix
   module ParamHelpers
     def rect(position)
-      warn "Warning: `ParamHelpers.rect` has been deprecated and will be removed in the next major version."
+      warn "Warning: `ParamHelpers.rect` has been deprecated and will be removed in the next major version.\n"
       @options[:rect] = position and return self if position.is_a?(String)
 
       @options[:rect] = [

--- a/test/units/param_helpers_test.rb
+++ b/test/units/param_helpers_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class ParamHelpers < Imgix::Test
+  def test_param_helpers_emits_dep_warning
+    msg = "Warning: `ParamHelpers.rect` has been deprecated and " \
+          "will be removed in the next major version.\n"
+
+    assert_output(nil,msg){
+        ||
+        client = Imgix::Client.new(host: 'test.imgix.net')
+        client.path('/images/demo.png').rect(x: 0, y: 50, width: 200, height: 300)
+    }
+  end
+end


### PR DESCRIPTION
The purpose of this PR is to warn users that `ParamHelpers.rect` has been
deprecated and will be removed from the next major version.