### PR TITLE
fix: deprecate ALIASES and corresponding define_method(s)

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -75,14 +75,16 @@ module Imgix
 
     ALIASES.each do |from, to|
       define_method from do |*args|
-        warn "Warning `Path.#{from}' has been deprecated and " \
-             "will be removed in the next major version.\n"
+        warn "Warning: `Path.#{from}' has been deprecated and " \
+             "will be removed in the next major version (along " \
+             "with all parameter `ALIASES`).\n"
         self.send(to, *args)
       end
 
       define_method "#{from}=" do |*args|
-        warn "Warning `Path.#{from}=' has been deprecated and " \
-             "will be removed in the next major version.\n"
+        warn "Warning: `Path.#{from}=' has been deprecated and " \
+             "will be removed in the next major version (along " \
+             "with all parameter `ALIASES`).\n"
         self.send("#{to}=", *args)
         return self
       end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -75,10 +75,14 @@ module Imgix
 
     ALIASES.each do |from, to|
       define_method from do |*args|
+        warn "Warning `Path.#{from}' has been deprecated and " \
+             "will be removed in the next major version.\n"
         self.send(to, *args)
       end
 
       define_method "#{from}=" do |*args|
+        warn "Warning `Path.#{from}=' has been deprecated and " \
+             "will be removed in the next major version.\n"
         self.send("#{to}=", *args)
         return self
       end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -14,7 +14,11 @@ class PathTest < Imgix::Test
   def test_signing_path_with_param
     url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
     path = client.path('/images/demo.png')
-    path.width = 200
+
+    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.width = 200
+      }
 
     assert_equal url, path.to_url
 
@@ -22,13 +26,22 @@ class PathTest < Imgix::Test
     assert_equal url, path.to_url(w: 200)
 
     path = client.path('/images/demo.png')
-    assert_equal url, path.width(200).to_url
+
+    assert_output(nil, "Warning `Path.width' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        assert_equal url, path.width(200).to_url
+      }
   end
 
   def test_resetting_defaults
     url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
     path = client.path('/images/demo.png')
-    path.height = 300
+    
+    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.height = 300
+      }
+
 
     assert_equal url, path.defaults.to_url(w: 200)
   end
@@ -40,7 +53,17 @@ class PathTest < Imgix::Test
     assert_equal url, path.to_url(h: 200, w: 200)
 
     path = client.path('/images/demo.png')
-    assert_equal url, path.height(200).width(200).to_url
+    assert_output(nil, "Warning `Path.height' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.height(200)
+    }
+
+    assert_output(nil, "Warning `Path.width' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.width(200)
+    }
+
+    assert_equal url, path.to_url
   end
 
   def test_path_with_multi_value_param_safely_encoded

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -15,10 +15,11 @@ class PathTest < Imgix::Test
     url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
     path = client.path('/images/demo.png')
 
-    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.width = 200
-      }
+    }
 
     assert_equal url, path.to_url
 
@@ -27,21 +28,22 @@ class PathTest < Imgix::Test
 
     path = client.path('/images/demo.png')
 
-    assert_output(nil, "Warning `Path.width' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.width' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         assert_equal url, path.width(200).to_url
-      }
+    }
   end
 
   def test_resetting_defaults
     url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
     path = client.path('/images/demo.png')
     
-    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.height = 300
-      }
-
+    }
 
     assert_equal url, path.defaults.to_url(w: 200)
   end
@@ -53,13 +55,17 @@ class PathTest < Imgix::Test
     assert_equal url, path.to_url(h: 200, w: 200)
 
     path = client.path('/images/demo.png')
-    assert_output(nil, "Warning `Path.height' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+
+    assert_output(nil, "Warning: `Path.height' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.height(200)
     }
 
-    assert_output(nil, "Warning `Path.width' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+
+    assert_output(nil, "Warning: `Path.width' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.width(200)
     }
 

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -13,20 +13,41 @@ class UrlTest < Imgix::Test
 
   def test_signing_with_one
     path = client.path(DEMO_IMAGE_PATH)
-    path.width = 200
+
+    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.width = 200
+    }
 
     assert_equal 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e', path.to_url
   end
 
   def test_signing_with_multiple_params
     path = client.path(DEMO_IMAGE_PATH)
-    path.height = 200
-    path.width = 200
+
+    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.height = 200
+    }
+
+    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.width = 200
+    }
     assert_equal 'https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a', path.to_url
 
     path = client.path(DEMO_IMAGE_PATH)
-    path.width = 200
-    path.height = 200
+
+    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.width = 200
+    }
+
+    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
+      "will be removed in the next major version.\n") {
+        path.height = 200
+    }
+
     assert_equal 'https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379', path.to_url
   end
 

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -14,8 +14,9 @@ class UrlTest < Imgix::Test
   def test_signing_with_one
     path = client.path(DEMO_IMAGE_PATH)
 
-    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.width = 200
     }
 
@@ -25,26 +26,31 @@ class UrlTest < Imgix::Test
   def test_signing_with_multiple_params
     path = client.path(DEMO_IMAGE_PATH)
 
-    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.height = 200
     }
 
-    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.width = 200
     }
+
     assert_equal 'https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a', path.to_url
 
     path = client.path(DEMO_IMAGE_PATH)
 
-    assert_output(nil, "Warning `Path.width=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.width = 200
     }
 
-    assert_output(nil, "Warning `Path.height=' has been deprecated and " \
-      "will be removed in the next major version.\n") {
+    assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
+      "will be removed in the next major version (along " \
+      "with all parameter `ALIASES`).\n") {
         path.height = 200
     }
 


### PR DESCRIPTION
The purpose of this PR is to `warn` that `ALIASES`, and the corresponding
`define_method`s that dynamically create accessor methods for each alias,
will be deprecated in the next MAJOR version.

The `ALIASES` feature is used within `path_test.rb` and `url_test.rb`,
so each usage has been wrapped with `assert_output` to catch and confirm
that the correct deprecation warning has been emitted.

We could get fancier and reduce the repetitive code here, but we might
want to hold off on that until _after_ we've actually deprecated (fully
removed) the code in question.