### PR TITLE
fix: warn host has been deprecated in favor of domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [Multiple Parameters](#multiple-parameters)
 - [Purge Cache](#purge-cache)
 - [URL encoding and signed imgix URLs](#url-encoding-and-signed-imgix-urls)
-- [What is the ixlib param on every request?](#what-is-the-ixlib-param-on-every-request)
+- [What is the `ixlib` param on every request?](#what-is-the-ixlib-param-on-every-request)
 - [Contributing](#contributing)
 
 ## Installation
@@ -44,12 +44,12 @@ Or install it yourself as:
 
 ## Usage
 
-Initialize a client with a `:host` and your `:secure_url_token`. By default, HTTPS URLs are generated, but you can toggle that by passing `use_https: false`.
+Initialize a client with a `:domain` and your `:secure_url_token`. By default, HTTPS URLs are generated, but you can toggle that by passing `use_https: false`.
 
 Call `Imgix::Client#path` with the resource path to get an `Imgix::Path` object back. You can then manipulate the path parameters, and call `Imgix#Path#to_url` when you're done.
 
 ``` ruby
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
 
 client.path('/images/demo.png').to_url(w: 200)
 #=> https://your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
@@ -67,12 +67,23 @@ path.defaults.width(300).to_url # Resets parameters
 path.rect(x: 0, y: 50, width: 200, height: 300).to_url # Rect helper
 ```
 
+**Deprecation Notice:** Usage of `:host` has been deprecated and will become invalid in the next major release.
+
+In the previous version, `:host` can be used to specify a domain for an `Imgix::Client` like so:
+
+```ruby
+Imgix::Client.new(host: 'demo.imgix.net', secure_url_token: 'token')
+```
+
+Code using `:host` like the above will continue to work until the next major release. While using `:host` will remain valid until the next major release, its usage will result in a deprecation warning. In order to resolve these deprecation warnings before upgrading to the new release, use `:domain` instead of `:host`.
+
+
 ## Srcset Generation
 
 The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.
 
 ```rb
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
 path = client.path('/images/demo.png')
 
 srcset = path.to_srcset
@@ -94,7 +105,7 @@ https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce34
 In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```rb
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)
 path = client.path('/images/demo.png')
 
 srcset = path.to_srcset(h:800, ar:'3:2', fit:'crop')
@@ -117,7 +128,7 @@ For more information to better understand `srcset`, we highly recommend [Eric Po
 In situations where specific widths are desired when generating `srcset` pairs, a user can specify them by passing an array of integers via `widths` to the `options` keyword argument.
 
 ```rb
-@client ||= Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+@client ||= Imgix::Client.new(domain: 'testing.imgix.net', include_library_param: false)
 .path('image.jpg')
 .to_srcset(options: { widths: [100, 500, 1000, 1800] })
 ```
@@ -140,7 +151,7 @@ The `srcset` width tolerance dictates the maximum tolerated size difference betw
 By default this rate is set to 8 percent, which we consider to be the ideal rate for maximizing cache hits without sacrificing visual quality. Users can specify their own width tolerance by passing a positive numeric value to `width_tolerance` within the `options` keyword argument:
 
 ```rb
-client = Imgix::Client.new(host: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
+client = Imgix::Client.new(domain: 'testing.imgix.net', secure_url_token: 'MYT0KEN', include_library_param: false)
 client.path('image.jpg').to_srcset(options: { width_tolerance: 0.20 })
 ```
 
@@ -159,7 +170,7 @@ https://testing.imgix.net/image.jpg?w=8192 8192w
 If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer via `min_srcset` and/or `max_srcset` to the `options` keyword parameters:
 
 ```rb
-client = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+client = Imgix::Client.new(domain: 'testing.imgix.net', include_library_param: false)
 client.path('image.jpg').to_srcset(options: { min_srcset: 500, max_srcset: 2000 })
 ```
 
@@ -192,7 +203,7 @@ This behavior will respect any overriding `q` value passed in as a parameter. Ad
 This behavior specifically occurs when a [fixed-size image](https://github.com/imgix/imgix-rb#fixed-image-rendering) is rendered, for example:
 
 ```rb
-srcset = Imgix::Client.new(host: 'testing.imgix.net', include_library_param: false)
+srcset = Imgix::Client.new(domain: 'testing.imgix.net', include_library_param: false)
 .path('image.jpg')
 .to_srcset(w:100)
 ```
@@ -222,7 +233,7 @@ path.noise_reduction(50,50)
 If you need to remove or update an image on imgix, you can purge it from our cache by initializing a client with your api_key, then calling Imgix::Client#purge with the resource path.
 
 ```ruby
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', api_key: 'your-key')
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', api_key: 'your-key')
 client.purge('/images/demo.png')
 ```
 
@@ -239,7 +250,7 @@ For security and diagnostic purposes, we sign all requests with the language and
 This can be disabled by including `include_library_param: false` in the instantiation Hash parameter for `Imgix::Client`:
 
 ```ruby
-client = Imgix::Client.new(host: 'your-subdomain.imgix.net', include_library_param: false )
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', include_library_param: false )
 ```
 
 ## Contributing

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -14,6 +14,10 @@ module Imgix
 
       @host = options[:host]
       validate_host!
+      warn "Warning: The identifier `host' has been deprecated and " \
+           "will\nappear as `domain' in the next major version, e.g. " \
+           "`@host'\nbecomes `@domain', `options[:host]' becomes " \
+           "`options[:domain]'.\n"
       @secure_url_token = options[:secure_url_token]
       @api_key = options[:api_key]
       @use_https = options[:use_https]

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -11,13 +11,22 @@ module Imgix
 
     def initialize(options = {})
       options = DEFAULTS.merge(options)
+      host, domain = options[:host], options[:domain]
 
-      @host = options[:host]
+      host_deprecated = "Warning: The identifier `host' has been deprecated and " \
+        "will\nappear as `domain' in the next major version, e.g. " \
+        "`@host'\nbecomes `@domain', `options[:host]' becomes " \
+        "`options[:domain]'.\n"
+
+      if host
+        warn host_deprecated
+        @host = host
+      elsif domain
+        @host = domain
+      end
+
       validate_host!
-      warn "Warning: The identifier `host' has been deprecated and " \
-           "will\nappear as `domain' in the next major version, e.g. " \
-           "`@host'\nbecomes `@domain', `options[:host]' becomes " \
-           "`options[:domain]'.\n"
+
       @secure_url_token = options[:secure_url_token]
       @api_key = options[:api_key]
       @use_https = options[:use_https]

--- a/test/units/param_helpers_test.rb
+++ b/test/units/param_helpers_test.rb
@@ -4,13 +4,19 @@ require 'test_helper'
 
 class ParamHelpers < Imgix::Test
   def test_param_helpers_emits_dep_warning
-    msg = "Warning: `ParamHelpers.rect` has been deprecated and " \
-          "will be removed in the next major version.\n"
+    host_warn = "Warning: The identifier `host' has been deprecated and " \
+                "will\nappear as `domain' in the next major version, e.g. " \
+                "`@host'\nbecomes `@domain', `options[:host]' becomes " \
+                "`options[:domain]'.\n"
 
-    assert_output(nil,msg){
-        ||
+    assert_output(nil, host_warn) {
         client = Imgix::Client.new(host: 'test.imgix.net')
-        client.path('/images/demo.png').rect(x: 0, y: 50, width: 200, height: 300)
+        rect_warn = "Warning: `ParamHelpers.rect` has been deprecated and " \
+                    "will be removed in the next major version.\n"
+
+        assert_output(nil, rect_warn){
+            client.path('/images/demo.png').rect(x: 0, y: 50, width: 200, height: 300)
+        }
     }
   end
 end

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -57,6 +57,21 @@ class UrlTest < Imgix::Test
     assert_equal 'https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379', path.to_url
   end
 
+  def test_domain_resolves_host_warn
+    assert_output(nil, "Warning: The identifier `host' has been deprecated and " \
+      "will\nappear as `domain' in the next major version, e.g. " \
+      "`@host'\nbecomes `@domain', `options[:host]' becomes " \
+      "`options[:domain]'.\n") {
+        Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
+    }
+
+
+    # Assert the output of this call (to both stdout and stderr) is nil.
+    assert_output(nil, nil) {
+      Imgix::Client.new(domain: 'demo.imgix.net', include_library_param: false)
+    }
+  end
+
 private
 
   def client


### PR DESCRIPTION
The purpose of this PR is to `warn` users that `host` has been deprecated
in favor of `domain`.
