### PR TITLE
chore: call-out @imgix/imgix-sdk-team in template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,9 +3,11 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: bug
-assignees: imgix-sdk-team
+assignees:
 
 ---
+
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,9 +3,11 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ''
-assignees: imgix-sdk-team
+assignees:
 
 ---
+
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
 
 **Before you submit:**
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,9 +3,11 @@ name: Question
 about: Ask a question about the project
 title: ''
 labels: ''
-assignees: imgix-sdk-team
+assignees:
 
 ---
+
+Please provide the following information and someone from @imgix/imgix-sdk-team will respond to your issue shortly.
 
 **Before you submit:**
 


### PR DESCRIPTION
GitHub issue templates can only be auto-assigned to individual users, but unfortunately not teams. As a middle ground, we decided to include a line in the template body specifically mentioning the @imgix/ imgix-sdk-team team so users know who to expect a response from.

----------

<img width="782" alt="Screen Shot 2020-07-21 at 11 13 47 AM" src="https://user-images.githubusercontent.com/15919091/88090982-417a4180-cb43-11ea-9431-20c25c9fea13.png">
