### PR TITLE
fix: warn prefix-with-args is deprecated

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -36,7 +36,7 @@ module Imgix
     end
 
     def path(path)
-      p = Path.new(prefix(path), @secure_url_token, path)
+      p = Path.new(new_prefix, @secure_url_token, path)
       p.ixlib("#{@library}-#{@version}") if @include_library_param
       p
     end
@@ -45,7 +45,7 @@ module Imgix
       token_error = 'Authentication token required'
       raise token_error if @api_key.nil?
 
-      url = prefix(path) + path
+      url = new_prefix + path
       uri = URI.parse('https://api.imgix.com/v2/image/purger')
 
       user_agent = { 'User-Agent' => "imgix #{@library}-#{@version}" }
@@ -62,6 +62,13 @@ module Imgix
     end
 
     def prefix(path)
+      msg = "Warning: `Client::prefix' will take zero arguments " \
+        "in the next major version.\n"
+      warn msg
+      new_prefix
+    end
+
+    def new_prefix
       "#{@use_https ? 'https' : 'http'}://#{@host}"
     end
 

--- a/test/units/param_helpers_test.rb
+++ b/test/units/param_helpers_test.rb
@@ -11,6 +11,7 @@ class ParamHelpers < Imgix::Test
 
     assert_output(nil, host_warn) {
         client = Imgix::Client.new(host: 'test.imgix.net')
+
         rect_warn = "Warning: `ParamHelpers.rect` has been deprecated and " \
                     "will be removed in the next major version.\n"
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -3,6 +3,27 @@
 require 'test_helper'
 
 class PathTest < Imgix::Test
+  def test_prefix_with_arg_warns
+    prefix_warn = "Warning: `Client::prefix' will take zero arguments " \
+      "in the next major version.\n"
+
+    assert_output(nil, prefix_warn) {
+      Imgix::Client.new(
+        domain: 'test.imgix.net',
+        include_library_param: false
+      ).prefix("")
+    }
+
+    # `new_prefix' is a placeholder until the bump, when it will become
+    # `prefix`.
+    assert_output(nil, nil) {
+      Imgix::Client.new(
+        domain: 'test.imgix.net',
+        include_library_param: false
+      ).new_prefix
+    }
+  end
+
   def test_creating_a_path
     path = client.path('/images/demo.png')
     assert_equal 'https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4', path.to_url


### PR DESCRIPTION
The purpose of this PR is to warn that calling `prefix` with args is
deprecated and will become invalid in the next major release. We
will be reducing the arity of this function to zero (as the argument
that is passed goes unused).