### PR TITLE
refactor: remove dead code

### DIFF
--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.0'
   spec.add_dependency 'addressable'
-  spec.add_development_dependency 'webmock'
 end


### PR DESCRIPTION
The purpose of this PR is to ensure we list gem dependencies once
Prior to this PR our Gemfile "listed webmock more than once" and
we receive a warning in our travis log:
```
468 $ bundle install --without development
469 Your Gemfile lists the gem webmock (>= 0) more than once.
470 You should probably keep only one of them.
471 Remove any duplicate entries and specify the gem only once (per group).
472 While it's not a problem now, it could cause errors if you change the version of one of them later.
473 Fetching gem metadata from https://rubygems.org/...........
...
```

Removing `spec.add_development_dependency 'webmock'` from our
`imgix.gemspec` file resolves this warning.

```
468 $ bundle install --without development
469 Fetching gem metadata from https://rubygems.org/...........
...
```

This resolves the warning, but isn't in the spirit of what we want to
do. What we want to do is use web mock as a dev-dependency when
we test, but not force users of our gem to download webmock.

Even though we were specify webmock as a dev-dep in the gemspec,
it is still being specified in our Gemfile and we `require` it in `test_helper.rb`.

This allows our build to pass because webmock is downloaded, but I think
this means that webmock is also downloaded along with our gem.