### PR TITLE
fix: ensure host is initialized

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -23,6 +23,8 @@ module Imgix
         @host = host
       elsif domain
         @host = domain
+      else
+        @host = host
       end
 
       validate_host!


### PR DESCRIPTION
The purpose of this PR is to ensure `@host` is initialized before use.