### PR TITLE
fix: deprecate api key versions

### DIFF
--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -49,8 +49,8 @@ module Imgix
         "imgix-rb version >= 4.0.0.\n"
       warn api_key_deprecated
 
-      token_error = 'Authentication token required'
-      raise token_error if @api_key.nil?
+      api_key_error = 'A valid api key is required to send purge requests'
+      raise api_key_error if @api_key.nil?
 
       url = new_prefix + path
       uri = URI.parse('https://api.imgix.com/v2/image/purger')

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -44,6 +44,11 @@ module Imgix
     end
 
     def purge(path)
+      api_key_deprecated = \
+        "Warning: Your `api_key` will no longer work after upgrading to\n" \
+        "imgix-rb version >= 4.0.0.\n"
+      warn api_key_deprecated
+
       token_error = 'Authentication token required'
       raise token_error if @api_key.nil?
 

--- a/test/units/purge_test.rb
+++ b/test/units/purge_test.rb
@@ -1,25 +1,57 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PurgeTest < Imgix::Test
   def test_runtime_error_without_api_key
-    assert_raises(RuntimeError) {
-      Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
-      .purge('https://demo.imgix.net/images/demo.png')
+    assert_raises(RuntimeError) do
+      mock_client(api_key: nil).purge(mock_image)
+    end
+  end
+
+  def test_successful_purge
+    stub_request(:post, endpoint).with(body: body).to_return(status: 200)
+
+    mock_client(api_key: '10adc394').purge('/images/demo.png')
+
+    assert_requested(
+      :post,
+      endpoint,
+      body: 'url=https%3A%2F%2Fdemo.imgix.net%2Fimages%2Fdemo.png',
+      headers: mock_headers,
+      times: 1
+    )
+  end
+
+  private
+
+  def mock_client(api_key: '')
+    Imgix::Client.new(
+      host: 'demo.imgix.net',
+      api_key: api_key,
+      include_library_param: false
+    )
+  end
+
+  def mock_headers
+    {
+      'Accept' => '*/*',
+      'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      'Authorization' => 'Basic MTBhZGMzOTQ6',
+      'Content-Type' => 'application/x-www-form-urlencoded',
+      'User-Agent' => "imgix rb-#{Imgix::VERSION}"
     }
   end
-  
-  def test_successful_purge
-    stub_request(:post, "https://api.imgix.com/v2/image/purger").
-      with(
-        body: {"url"=>"https://demo.imgix.net/images/demo.png"}).
-      to_return(status: 200)
 
-    Imgix::Client.new(host: 'demo.imgix.net', api_key: '10adc394')
-    .purge('/images/demo.png')
-    
-    assert_requested :post, 'https://api.imgix.com/v2/image/purger',
-      body:  'url=https%3A%2F%2Fdemo.imgix.net%2Fimages%2Fdemo.png',
-      headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Basic MTBhZGMzOTQ6', 'Content-Type'=>'application/x-www-form-urlencoded', 'User-Agent'=>"imgix rb-#{ Imgix::VERSION}"},
-      times: 1
+  def mock_image
+    'https://demo.imgix.net/images/demo.png'
+  end
+
+  def endpoint
+    'https://api.imgix.com/v2/image/purger'
+  end
+
+  def body
+    { 'url' => mock_image }
   end
 end

--- a/test/units/purge_test.rb
+++ b/test/units/purge_test.rb
@@ -9,6 +9,14 @@ class PurgeTest < Imgix::Test
     end
   end
 
+  def test_purger_version_warns
+    stub_request(:post, endpoint).with(body: body).to_return(status: 200)
+
+    assert_output(nil, deprecation_warning) do
+      mock_client(api_key: '10adc394').purge('/images/demo.png')
+    end
+  end
+
   def test_successful_purge
     stub_request(:post, endpoint).with(body: body).to_return(status: 200)
 
@@ -27,7 +35,7 @@ class PurgeTest < Imgix::Test
 
   def mock_client(api_key: '')
     Imgix::Client.new(
-      host: 'demo.imgix.net',
+      domain: 'demo.imgix.net',
       api_key: api_key,
       include_library_param: false
     )
@@ -53,5 +61,10 @@ class PurgeTest < Imgix::Test
 
   def body
     { 'url' => mock_image }
+  end
+
+  def deprecation_warning
+    "Warning: Your `api_key` will no longer work after upgrading to\n" \
+    "imgix-rb version >= 4.0.0.\n"
   end
 end


### PR DESCRIPTION
The purpose of this PR is to deprecate these api key versions. These api
keys will continue functioning in the subsequent minor version bump.

However, in the next major release imgix-rb will use the new style api keys
that correspond to the new endpoint.