### PR TITLE
docs(readme): deprecation notice for pre-4.0 api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ path.noise_reduction(50,50)
 
 ## Purge Cache
 
+**Deprecation Notice:** The API keys used in `Imgix::Client#purge` version `3.3.X` have been deprecated. To utilize the updated `Imgix::Client#purge` method in version `4.0.0`, please regenerate your API key at `http://dashboard.imgix.com/api-keys`. Feel free to reach out to our [support line](support@imgix.com) if you have any questions or concerns.
+
 If you need to remove or update an image on imgix, you can purge it from our cache by initializing a client with your api_key, then calling Imgix::Client#purge with the resource path.
 
 ```ruby


### PR DESCRIPTION
The purpose of this PR is to document the deprecation of "old-style", shorter,
api keys in favor of new style api keys that can be generated by visiting the
link [here](https://dashboard.imgix.com/api-keys).

