### PR TITLE
refactor(style): enforce double quoted strings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+Style/StringLiterals:
+  EnforcedStyle: double_quotes

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require_relative 'lib/imgix/version'
+require_relative "lib/imgix/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'imgix'
+  spec.name          = "imgix"
   spec.version       = Imgix::VERSION
-  spec.authors       = ['Kelly Sutton', 'Sam Soffes', 'Ryan LeFevre', 'Antony Denyer', 'Paul Straw', 'Sherwin Heydarbeygi']
-  spec.email         = ['kelly@imgix.com', 'sam@soff.es', 'ryan@layervault.com', 'email@antonydenyer.co.uk', 'paul@imgix.com', 'sherwin@imgix.com']
-  spec.description   = 'Easily create and sign imgix URLs.'
-  spec.summary       = 'Official Ruby Gem for easily creating and signing imgix URLs.'
-  spec.homepage      = 'https://github.com/imgix/imgix-rb'
-  spec.license       = 'MIT'
+  spec.authors       = ["Kelly Sutton", "Sam Soffes", "Ryan LeFevre", "Antony Denyer", "Paul Straw", "Sherwin Heydarbeygi"]
+  spec.email         = ["kelly@imgix.com", "sam@soff.es", "ryan@layervault.com", "email@antonydenyer.co.uk", "paul@imgix.com", "sherwin@imgix.com"]
+  spec.description   = "Easily create and sign imgix URLs."
+  spec.summary       = "Official Ruby Gem for easily creating and signing imgix URLs."
+  spec.homepage      = "https://github.com/imgix/imgix-rb"
+  spec.license       = "MIT"
 
   spec.metadata = {
-    'bug_tracker_uri'   => 'https://github.com/imgix/imgix-rb/issues',
-    'changelog_uri'     => 'https://github.com/imgix/imgix-rb/blob/main/CHANGELOG.md',
-    'documentation_uri' => "https://www.rubydoc.info/gems/imgix/#{spec.version}",
-    'source_code_uri'   => "https://github.com/imgix/imgix-rb/tree/#{spec.version}"
+    "bug_tracker_uri" => "https://github.com/imgix/imgix-rb/issues",
+    "changelog_uri" => "https://github.com/imgix/imgix-rb/blob/main/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/imgix/#{spec.version}",
+    "source_code_uri" => "https://github.com/imgix/imgix-rb/tree/#{spec.version}"
   }
 
   spec.files         = `git ls-files`.split($/)
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 1.9.0'
-  spec.add_dependency 'addressable'
-  spec.add_development_dependency 'webmock'
+  spec.required_ruby_version = ">= 1.9.0"
+  spec.add_dependency "addressable"
+  spec.add_development_dependency "webmock"
 end

--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -19,10 +19,13 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/imgix/imgix-rb/tree/#{spec.version}"
   }
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ['lib']
+  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|.github)/}) }
+  end
+
+  spec.bindir        = "exe"
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 1.9.0"
   spec.add_dependency "addressable"

--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'imgix/version'
-require 'imgix/client'
-require 'imgix/path'
+require "imgix/version"
+require "imgix/client"
+require "imgix/path"
 
 module Imgix
   # regex pattern used to determine if a domain is valid
@@ -22,7 +22,7 @@ module Imgix
     increment_percentage = tolerance || DEFAULT_WIDTH_TOLERANCE
 
     unless increment_percentage.is_a?(Numeric) && increment_percentage > 0
-      width_increment_error = 'error: `width_tolerance` must be a positive `Numeric` value'
+      width_increment_error = "error: `width_tolerance` must be a positive `Numeric` value"
       raise ArgumentError, width_increment_error
     end
 

--- a/lib/imgix/client.rb
+++ b/lib/imgix/client.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'digest'
-require 'addressable/uri'
-require 'net/http'
-require 'uri'
+require "digest"
+require "addressable/uri"
+require "net/http"
+require "uri"
 
 module Imgix
   class Client
@@ -11,7 +11,8 @@ module Imgix
 
     def initialize(options = {})
       options = DEFAULTS.merge(options)
-      host, domain = options[:host], options[:domain]
+      host = options[:host]
+      domain = options[:domain]
 
       host_deprecated = "Warning: The identifier `host' has been deprecated and " \
         "will\nappear as `domain' in the next major version, e.g. " \
@@ -33,7 +34,7 @@ module Imgix
       @api_key = options[:api_key]
       @use_https = options[:use_https]
       @include_library_param = options.fetch(:include_library_param, true)
-      @library = options.fetch(:library_param, 'rb')
+      @library = options.fetch(:library_param, "rb")
       @version = options.fetch(:library_version, Imgix::VERSION)
     end
 
@@ -49,16 +50,16 @@ module Imgix
         "imgix-rb version >= 4.0.0.\n"
       warn api_key_deprecated
 
-      api_key_error = 'A valid api key is required to send purge requests'
+      api_key_error = "A valid api key is required to send purge requests"
       raise api_key_error if @api_key.nil?
 
       url = new_prefix + path
-      uri = URI.parse('https://api.imgix.com/v2/image/purger')
+      uri = URI.parse("https://api.imgix.com/v2/image/purger")
 
-      user_agent = { 'User-Agent' => "imgix #{@library}-#{@version}" }
+      user_agent = { "User-Agent" => "imgix #{@library}-#{@version}" }
 
       req = Net::HTTP::Post.new(uri.path, user_agent)
-      req.basic_auth @api_key, ''
+      req.basic_auth @api_key, ""
       req.set_form_data({ url: url })
 
       sock = Net::HTTP.new(uri.host, uri.port)
@@ -68,7 +69,7 @@ module Imgix
       res
     end
 
-    def prefix(path)
+    def prefix(_path)
       msg = "Warning: `Client::prefix' will take zero arguments " \
         "in the next major version.\n"
       warn msg
@@ -82,16 +83,14 @@ module Imgix
     private
 
     def validate_host!
-      host_error = 'The :host option must be specified'
+      host_error = "The :host option must be specified"
       raise ArgumentError, host_error if @host.nil?
 
-      domain_error = 'Domains must be passed in as fully-qualified'\
-                     'domain names and should not include a protocol'\
+      domain_error = "Domains must be passed in as fully-qualified"\
+                     "domain names and should not include a protocol"\
                      'or any path element, i.e. "example.imgix.net"'\
 
-      if @host.match(DOMAIN_REGEX).nil?
-        raise ArgumentError, domain_error
-      end
+      raise ArgumentError, domain_error if @host.match(DOMAIN_REGEX).nil?
     end
   end
 end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'base64'
-require 'cgi/util'
-require 'erb'
-require 'imgix/param_helpers'
+require "base64"
+require "cgi/util"
+require "erb"
+require "imgix/param_helpers"
 
 module Imgix
   class Path
@@ -31,14 +31,14 @@ module Imgix
       quality: :q
     }.freeze
 
-    def initialize(prefix, secure_url_token, path = '/')
+    def initialize(prefix, secure_url_token, path = "/")
       @prefix = prefix
       @secure_url_token = secure_url_token
       @path = path
       @options = {}
 
       @path = CGI.escape(@path) if /^https?/ =~ @path
-      @path = "/#{@path}" if @path[0] != '/'
+      @path = "/#{@path}" if @path[0] != "/"
       @target_widths = TARGET_WIDTHS.call(DEFAULT_WIDTH_TOLERANCE, MIN_WIDTH, MAX_WIDTH)
     end
 
@@ -49,7 +49,7 @@ module Imgix
       url = @prefix + path_and_params
 
       if @secure_url_token
-        url += (has_query? ? '&' : '?') + "s=#{signature}"
+        url += (has_query? ? "&" : "?") + "s=#{signature}"
       end
 
       @options = prev_options
@@ -61,15 +61,15 @@ module Imgix
       self
     end
 
-    def method_missing(method, *args, &block)
-      key = method.to_s.gsub('=', '')
-      if args.length == 0
+    def method_missing(method, *args)
+      key = method.to_s.gsub("=", "")
+      if args.empty?
         return @options[key]
-      elsif args.first.nil? && @options.has_key?(key)
+      elsif args.first.nil? && @options.key?(key)
         @options.delete(key) and return self
       end
 
-      @options[key] = args.join(',')
+      @options[key] = args.join(",")
       self
     end
 
@@ -78,14 +78,14 @@ module Imgix
         warn "Warning: `Path.#{from}' has been deprecated and " \
              "will be removed in the next major version (along " \
              "with all parameter `ALIASES`).\n"
-        self.send(to, *args)
+        send(to, *args)
       end
 
       define_method "#{from}=" do |*args|
         warn "Warning: `Path.#{from}=' has been deprecated and " \
              "will be removed in the next major version (along " \
              "with all parameter `ALIASES`).\n"
-        self.send("#{to}=", *args)
+        send("#{to}=", *args)
         return self
       end
     end
@@ -99,10 +99,10 @@ module Imgix
       aspect_ratio = @options[:ar]
 
       srcset = if width || (height && aspect_ratio)
-                 build_dpr_srcset(options: options, params: @options)
-               else
-                 build_srcset_pairs(options: options, params: @options)
-               end
+          build_dpr_srcset(options: options, params: @options)
+        else
+          build_srcset_pairs(options: options, params: @options)
+        end
 
       @options = prev_options
       srcset
@@ -127,15 +127,15 @@ module Imgix
         else
           escaped_key << "=" << ERB::Util.url_encode(val.to_s)
         end
-      end.join('&')
+      end.join("&")
     end
 
     def has_query?
-      query.length > 0
+      !query.empty?
     end
 
     def build_srcset_pairs(options:, params:)
-      srcset = ''
+      srcset = ""
 
       widths = options[:widths] || []
       width_tolerance = options[:width_tolerance] || DEFAULT_WIDTH_TOLERANCE
@@ -162,7 +162,7 @@ module Imgix
     end
 
     def build_dpr_srcset(options:, params:)
-      srcset = ''
+      srcset = ""
 
       disable_variable_quality = options[:disable_variable_quality] || false
       validate_variable_qualities!(disable_variable_quality)
@@ -173,9 +173,7 @@ module Imgix
       target_ratios.each do |ratio|
         params[:dpr] = ratio
 
-        unless disable_variable_quality
-          params[:q] = quality || DPR_QUALITY[ratio]
-        end
+        params[:q] = quality || DPR_QUALITY[ratio] unless disable_variable_quality
 
         srcset += "#{to_url(params)} #{ratio}x,\n"
       end
@@ -184,15 +182,13 @@ module Imgix
     end
 
     def validate_width_tolerance!(width_tolerance)
-      width_increment_error = 'error: `width_tolerance` must be a positive `Numeric` value'
+      width_increment_error = "error: `width_tolerance` must be a positive `Numeric` value"
 
-      if !width_tolerance.is_a?(Numeric) || width_tolerance <= 0
-        raise ArgumentError, width_increment_error
-      end
+      raise ArgumentError, width_increment_error if !width_tolerance.is_a?(Numeric) || width_tolerance <= 0
     end
 
     def validate_widths!(widths)
-      widths_error = 'error: `widths` must be an array of positive `Numeric` values'
+      widths_error = "error: `widths` must be an array of positive `Numeric` values"
       raise ArgumentError, widths_error unless widths.is_a?(Array)
 
       all_positive_integers = widths.all? { |i| i.is_a?(Integer) && i > 0 }
@@ -200,18 +196,14 @@ module Imgix
     end
 
     def validate_range!(min_srcset, max_srcset)
-      range_numeric_error = 'error: `min_width` and `max_width` must be positive `Numeric` values'
-      unless min_srcset.is_a?(Numeric) && max_srcset.is_a?(Numeric)
-        raise ArgumentError, range_numeric_error
-      end
+      range_numeric_error = "error: `min_width` and `max_width` must be positive `Numeric` values"
+      raise ArgumentError, range_numeric_error unless min_srcset.is_a?(Numeric) && max_srcset.is_a?(Numeric)
 
-      unless min_srcset > 0 && max_srcset > 0
-        raise ArgumentError, range_numeric_error
-      end
+      raise ArgumentError, range_numeric_error unless min_srcset > 0 && max_srcset > 0
     end
 
     def validate_variable_qualities!(disable_quality)
-      disable_quality_error = 'error: `disable_quality` must be a Boolean value'
+      disable_quality_error = "error: `disable_quality` must be a Boolean value"
       unless disable_quality.is_a?(TrueClass) || disable_quality.is_a?(FalseClass)
         raise ArgumentError, disable_quality_error
       end

--- a/lib/imgix/version.rb
+++ b/lib/imgix/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Imgix
-  VERSION = '3.4.0'
+  VERSION = "3.4.0"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'rubygems'
-require 'bundler'
+require "rubygems"
+require "bundler"
 Bundler.require :test
 
-require 'minitest/autorun'
-require 'imgix'
-require 'webmock/minitest'
+require "minitest/autorun"
+require "imgix"
+require "webmock/minitest"
 
 class Imgix::Test < MiniTest::Test
 end

--- a/test/units/param_helpers_test.rb
+++ b/test/units/param_helpers_test.rb
@@ -15,8 +15,8 @@ class ParamHelpers < Imgix::Test
         rect_warn = "Warning: `ParamHelpers.rect` has been deprecated and " \
                     "will be removed in the next major version.\n"
 
-        assert_output(nil, rect_warn){
-            client.path('/images/demo.png').rect(x: 0, y: 50, width: 200, height: 300)
+        assert_output(nil, rect_warn) {
+            client.path("/images/demo.png").rect(x: 0, y: 50, width: 200, height: 300)
         }
     }
   end

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -1,163 +1,156 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class PathTest < Imgix::Test
   def test_prefix_with_arg_warns
     prefix_warn = "Warning: `Client::prefix' will take zero arguments " \
       "in the next major version.\n"
 
-    assert_output(nil, prefix_warn) {
+    assert_output(nil, prefix_warn) do
       Imgix::Client.new(
-        domain: 'test.imgix.net',
+        domain: "test.imgix.net",
         include_library_param: false
       ).prefix("")
-    }
+    end
 
     # `new_prefix' is a placeholder until the bump, when it will become
     # `prefix`.
-    assert_output(nil, nil) {
+    assert_output(nil, nil) do
       Imgix::Client.new(
-        domain: 'test.imgix.net',
+        domain: "test.imgix.net",
         include_library_param: false
       ).new_prefix
-    }
+    end
   end
 
   def test_creating_a_path
-    path = client.path('/images/demo.png')
-    assert_equal 'https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4', path.to_url
+    path = client.path("/images/demo.png")
+    assert_equal "https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4", path.to_url
 
-    path = client.path('images/demo.png')
-    assert_equal 'https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4', path.to_url
+    path = client.path("images/demo.png")
+    assert_equal "https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4", path.to_url
   end
 
   def test_signing_path_with_param
-    url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
-    path = client.path('/images/demo.png')
+    url = "https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e"
+    path = client.path("/images/demo.png")
 
     assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.width = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.width = 200
+    end
 
     assert_equal url, path.to_url
 
-    path = client.path('/images/demo.png')
+    path = client.path("/images/demo.png")
     assert_equal url, path.to_url(w: 200)
 
-    path = client.path('/images/demo.png')
+    path = client.path("/images/demo.png")
 
     assert_output(nil, "Warning: `Path.width' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        assert_equal url, path.width(200).to_url
-    }
+      "with all parameter `ALIASES`).\n") do
+      assert_equal url, path.width(200).to_url
+    end
   end
 
   def test_resetting_defaults
-    url = 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e'
-    path = client.path('/images/demo.png')
-    
+    url = "https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e"
+    path = client.path("/images/demo.png")
+
     assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.height = 300
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.height = 300
+    end
 
     assert_equal url, path.defaults.to_url(w: 200)
   end
 
   def test_path_with_multiple_params
-    url = 'https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a'
-    path = client.path('/images/demo.png')
+    url = "https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a"
+    path = client.path("/images/demo.png")
 
     assert_equal url, path.to_url(h: 200, w: 200)
 
-    path = client.path('/images/demo.png')
+    path = client.path("/images/demo.png")
 
     assert_output(nil, "Warning: `Path.height' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.height(200)
-    }
-
+      "with all parameter `ALIASES`).\n") do
+      path.height(200)
+    end
 
     assert_output(nil, "Warning: `Path.width' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.width(200)
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.width(200)
+    end
 
     assert_equal url, path.to_url
   end
 
   def test_path_with_multi_value_param_safely_encoded
-    url = 'https://demo.imgix.net/images/demo.png?markalign=middle%2Ccenter&s=f0d0e28a739f022638f4ba6dddf9b694'
-    path = client.path('/images/demo.png')
+    url = "https://demo.imgix.net/images/demo.png?markalign=middle%2Ccenter&s=f0d0e28a739f022638f4ba6dddf9b694"
+    path = client.path("/images/demo.png")
 
-    assert_equal url, path.markalign('middle', 'center').to_url
+    assert_equal url, path.markalign("middle", "center").to_url
   end
 
   def test_param_keys_are_escaped
-    ix_url = unsigned_client.path('demo.png').to_url({
-      :'hello world' => 'interesting'
-    })
+    ix_url = unsigned_client.path("demo.png").to_url({ "hello world" => "interesting" })
 
     assert_equal "https://demo.imgix.net/demo.png?hello%20world=interesting", ix_url
   end
 
   def test_param_values_are_escaped
-    ix_url = unsigned_client.path('demo.png').to_url({
-      hello_world: '/foo"> <script>alert("hacked")</script><'
-    })
+    ix_url = unsigned_client.path("demo.png").to_url({ hello_world: "/foo\"> <script>alert(\"hacked\")</script><" })
 
     assert_equal "https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C", ix_url
   end
 
   def test_base64_param_variants_are_base64_encoded
-    ix_url = unsigned_client.path('~text').to_url({
-      txt64: 'I cannøt belîév∑ it wors! 😱'
-    })
+    ix_url = unsigned_client.path("~text").to_url({txt64: "I cannøt belîév∑ it wors! 😱"})
 
     assert_equal "https://demo.imgix.net/~text?txt64=SSBjYW5uw7h0IGJlbMOuw6l24oiRIGl0IHdvcu-jv3MhIPCfmLE", ix_url
   end
 
   def test_host_is_required
-    assert_raises(ArgumentError) {Imgix::Client.new}
+    assert_raises(ArgumentError) { Imgix::Client.new }
   end
 
   def test_token_is_optional
-    client = Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
-    url = 'https://demo.imgix.net/images/demo.png'
-    path = client.path('/images/demo.png')
+    client = Imgix::Client.new(host: "demo.imgix.net", include_library_param: false)
+    url = "https://demo.imgix.net/images/demo.png"
+    path = client.path("/images/demo.png")
 
     assert_equal url, path.to_url
   end
 
   def test_https_is_optional
-    client = Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false, use_https: false)
-    url = 'http://demo.imgix.net/images/demo.png'
-    path = client.path('/images/demo.png')
+    client = Imgix::Client.new(host: "demo.imgix.net", include_library_param: false, use_https: false)
+    url = "http://demo.imgix.net/images/demo.png"
+    path = client.path("/images/demo.png")
 
     assert_equal url, path.to_url
   end
 
   def test_full_url
-    path = 'https://google.com/cats.gif'
+    path = "https://google.com/cats.gif"
 
     assert_equal "https://demo.imgix.net/#{CGI.escape(path)}?s=e686099fbba86fc2b8141d3c1ff60605", client.path(path).to_url
   end
 
   def test_full_url_with_a_space
-    path = 'https://my-demo-site.com/files/133467012/avatar icon.png'
+    path = "https://my-demo-site.com/files/133467012/avatar icon.png"
     assert_equal "https://demo.imgix.net/#{CGI.escape(path)}?s=35ca40e2e7b6bd208be2c4f7073f658e", client.path(path).to_url
   end
 
   def test_include_library_param
-    client = Imgix::Client.new(host: 'demo.imgix.net') # enabled by default
-    url = client.path('/images/demo.png').to_url
+    client = Imgix::Client.new(host: "demo.imgix.net") # enabled by default
+    url = client.path("/images/demo.png").to_url
 
     assert_equal "ixlib=rb-#{Imgix::VERSION}", URI(url).query
   end
@@ -165,18 +158,19 @@ class PathTest < Imgix::Test
   def test_configure_library_param
     library = "sinatra"
     version = Imgix::VERSION
-    client = Imgix::Client.new(host: 'demo.imgix.net', library_param: library, library_version: version) # enabled by default
-    url = client.path('/images/demo.png').to_url
+    client = Imgix::Client.new(host: "demo.imgix.net", library_param: library, library_version: version) # enabled by default
+    url = client.path("/images/demo.png").to_url
 
     assert_equal "ixlib=#{library}-#{version}", URI(url).query
   end
 
-private
+  private
+
   def client
-    @client ||= Imgix::Client.new(host: 'demo.imgix.net', secure_url_token: '10adc394', include_library_param: false)
+    @client ||= Imgix::Client.new(host: "demo.imgix.net", secure_url_token: "10adc394", include_library_param: false)
   end
 
   def unsigned_client
-    @unsigned_client ||= Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
+    @unsigned_client ||= Imgix::Client.new(host: "demo.imgix.net", include_library_param: false)
   end
 end

--- a/test/units/purge_test.rb
+++ b/test/units/purge_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class PurgeTest < Imgix::Test
   def test_runtime_error_without_api_key
@@ -13,19 +13,19 @@ class PurgeTest < Imgix::Test
     stub_request(:post, endpoint).with(body: body).to_return(status: 200)
 
     assert_output(nil, deprecation_warning) do
-      mock_client(api_key: '10adc394').purge('/images/demo.png')
+      mock_client(api_key: "10adc394").purge("/images/demo.png")
     end
   end
 
   def test_successful_purge
     stub_request(:post, endpoint).with(body: body).to_return(status: 200)
 
-    mock_client(api_key: '10adc394').purge('/images/demo.png')
+    mock_client(api_key: "10adc394").purge("/images/demo.png")
 
     assert_requested(
       :post,
       endpoint,
-      body: 'url=https%3A%2F%2Fdemo.imgix.net%2Fimages%2Fdemo.png',
+      body: "url=https%3A%2F%2Fdemo.imgix.net%2Fimages%2Fdemo.png",
       headers: mock_headers,
       times: 1
     )
@@ -33,9 +33,9 @@ class PurgeTest < Imgix::Test
 
   private
 
-  def mock_client(api_key: '')
+  def mock_client(api_key: "")
     Imgix::Client.new(
-      domain: 'demo.imgix.net',
+      domain: "demo.imgix.net",
       api_key: api_key,
       include_library_param: false
     )
@@ -43,24 +43,24 @@ class PurgeTest < Imgix::Test
 
   def mock_headers
     {
-      'Accept' => '*/*',
-      'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-      'Authorization' => 'Basic MTBhZGMzOTQ6',
-      'Content-Type' => 'application/x-www-form-urlencoded',
-      'User-Agent' => "imgix rb-#{Imgix::VERSION}"
+      "Accept" => "*/*",
+      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "Authorization" => "Basic MTBhZGMzOTQ6",
+      "Content-Type" => "application/x-www-form-urlencoded",
+      "User-Agent" => "imgix rb-#{Imgix::VERSION}"
     }
   end
 
   def mock_image
-    'https://demo.imgix.net/images/demo.png'
+    "https://demo.imgix.net/images/demo.png"
   end
 
   def endpoint
-    'https://api.imgix.com/v2/image/purger'
+    "https://api.imgix.com/v2/image/purger"
   end
 
   def body
-    { 'url' => mock_image }
+    { "url" => mock_image }
   end
 
   def deprecation_warning

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module SrcsetTest
   RESOLUTIONS = [
@@ -12,9 +12,9 @@ module SrcsetTest
 
   DPR_QUALITY = [75, 50, 35, 23, 20].freeze
 
-  DOMAIN = 'testing.imgix.net'
-  TOKEN = 'MYT0KEN'
-  JPG_PATH = 'image.jpg'
+  DOMAIN = "testing.imgix.net"
+  TOKEN = "MYT0KEN"
+  JPG_PATH = "image.jpg"
 
   def mock_client
     Imgix::Client.new(
@@ -32,20 +32,20 @@ module SrcsetTest
   end
 
   def signature_base(params)
-    TOKEN + '/' + JPG_PATH + params
+    TOKEN + "/" + JPG_PATH + params
   end
 
   def get_sig_from(src)
-    src.slice(src.index('s=') + 2, src.length)
+    src.slice(src.index("s=") + 2, src.length)
   end
 
   def get_params_from(src)
-    src[src.index('?')..src.index('s=') - 2]
+    src[src.index("?")..src.index("s=") - 2]
   end
 
   def get_expected_signature(src)
     # Ensure signature param exists.
-    assert_includes src, 's='
+    assert_includes src, "s="
 
     params = get_params_from(src)
     signature_base = signature_base(params)
@@ -60,17 +60,17 @@ module SrcsetTest
       srcset = path.to_srcset
 
       expected_number_of_pairs = 31
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
       resolutions = RESOLUTIONS
       srcset = path.to_srcset
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], resolutions[i])
       end
     end
@@ -88,8 +88,8 @@ module SrcsetTest
     def test_srcset_in_dpr_form
       device_pixel_ratio = 1
 
-      srcset.split(',').map do |src|
-        ratio = src.split(' ')[1]
+      srcset.split(",").map do |src|
+        ratio = src.split(" ")[1]
         assert_equal "#{device_pixel_ratio}x", ratio
         device_pixel_ratio += 1
       end
@@ -97,16 +97,16 @@ module SrcsetTest
 
     def test_srcset_has_dpr_params
       i = 1
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         assert_includes src, "dpr=#{i}"
         i += 1
       end
     end
 
     def test_srcset_signs_urls
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         expected_signature = get_expected_signature(src)
 
         assert_includes src, expected_signature
@@ -115,7 +115,7 @@ module SrcsetTest
 
     def test_srcset_has_variable_qualities
       i = 0
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{DPR_QUALITY[i]}"
         i += 1
       end
@@ -125,7 +125,7 @@ module SrcsetTest
       quality_override = 100
       srcset = mock_signed_client.to_srcset(w: 100, q: quality_override)
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
@@ -136,8 +136,8 @@ module SrcsetTest
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
-        assert(not(src.include?('q=')))
+      srcset.split(",").map do |src|
+        assert(!src.include?("q="))
       end
     end
 
@@ -148,7 +148,7 @@ module SrcsetTest
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
@@ -165,32 +165,32 @@ module SrcsetTest
 
     def test_srcset_generates_width_pairs
       expected_number_of_pairs = 31
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
       resolutions = RESOLUTIONS
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], resolutions[i])
       end
     end
 
     def test_srcset_respects_height_parameter
-      srcset.split(',').map do |src|
-        assert_includes src, 'h='
+      srcset.split(",").map do |src|
+        assert_includes src, "h="
       end
     end
 
     def test_srcset_within_bounds
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, 100
       assert_operator max, :<=, 8192
@@ -201,13 +201,13 @@ module SrcsetTest
       increment_allowed = 0.17
 
       # create an array of widths
-      widths = srcset.split(',').map do |src|
-        src.split(' ')[1].to_i
+      widths = srcset.split(",").map do |src|
+        src.split(" ")[1].to_i
       end
 
       prev = widths[0]
 
-      for i in 1..widths.length - 1
+      (1..widths.length - 1).each do |i|
         element = widths[i]
         assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
         prev = element
@@ -215,8 +215,8 @@ module SrcsetTest
     end
 
     def test_srcset_signs_urls
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         expected_signature = get_expected_signature(src)
 
         assert_includes src, expected_signature
@@ -235,8 +235,8 @@ module SrcsetTest
 
     def test_srcset_in_dpr_form
       device_pixel_ratio = 1
-      srcset.split(',').map do |src|
-        ratio = src.split(' ')[1]
+      srcset.split(",").map do |src|
+        ratio = src.split(" ")[1]
         assert_equal "#{device_pixel_ratio}x", ratio
         device_pixel_ratio += 1
       end
@@ -244,16 +244,16 @@ module SrcsetTest
 
     def test_srcset_has_dpr_params
       i = 1
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         assert_includes src, "dpr=#{i}"
         i += 1
       end
     end
 
     def test_srcset_signs_urls
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         expected_signature = get_expected_signature(src)
 
         assert_includes src, expected_signature
@@ -262,7 +262,7 @@ module SrcsetTest
 
     def test_srcset_has_variable_qualities
       i = 0
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{DPR_QUALITY[i]}"
         i += 1
       end
@@ -272,7 +272,7 @@ module SrcsetTest
       quality_override = 100
       srcset = mock_signed_client.to_srcset(w: 100, h: 100, q: quality_override)
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
@@ -283,8 +283,8 @@ module SrcsetTest
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
-        assert(not(src.include?('q=')))
+      srcset.split(",").map do |src|
+        assert(!src.include?("q="))
       end
     end
 
@@ -295,7 +295,7 @@ module SrcsetTest
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
@@ -312,25 +312,25 @@ module SrcsetTest
 
     def test_srcset_generates_width_pairs
       expected_number_of_pairs = 31
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], RESOLUTIONS[i])
       end
     end
 
     def test_srcset_within_bounds
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, 100
       assert_operator max, :<=, 8192
@@ -341,13 +341,13 @@ module SrcsetTest
       increment_allowed = 0.17
 
       # create an array of widths
-      widths = srcset.split(',').map do |src|
-        src.split(' ')[1].to_i
+      widths = srcset.split(",").map do |src|
+        src.split(" ")[1].to_i
       end
 
       prev = widths[0]
 
-      for i in 1..widths.length - 1
+      (1..widths.length - 1).each do |i|
         element = widths[i]
         assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
         prev = element
@@ -355,8 +355,8 @@ module SrcsetTest
     end
 
     def test_srcset_signs_urls
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         expected_signature = get_expected_signature(src)
 
         assert_includes src, expected_signature
@@ -366,7 +366,7 @@ module SrcsetTest
     private
 
     def srcset
-      @client ||= mock_signed_client.to_srcset(ar: '3:2')
+      @client ||= mock_signed_client.to_srcset(ar: "3:2")
     end
   end
 
@@ -376,8 +376,8 @@ module SrcsetTest
     def test_srcset_in_dpr_form
       device_pixel_ratio = 1
 
-      srcset.split(',').map do |src|
-        ratio = src.split(' ')[1]
+      srcset.split(",").map do |src|
+        ratio = src.split(" ")[1]
         assert_equal "#{device_pixel_ratio}x", ratio
         device_pixel_ratio += 1
       end
@@ -385,16 +385,16 @@ module SrcsetTest
 
     def test_srcset_has_dpr_params
       i = 1
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         assert_includes src, "dpr=#{i}"
         i += 1
       end
     end
 
     def test_srcset_signs_urls
-      srcset.split(',').map do |srcset_split|
-        src = srcset_split.split(' ')[0]
+      srcset.split(",").map do |srcset_split|
+        src = srcset_split.split(" ")[0]
         expected_signature = get_expected_signature(src)
 
         assert_includes src, expected_signature
@@ -403,7 +403,7 @@ module SrcsetTest
 
     def test_srcset_has_variable_qualities
       i = 0
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{DPR_QUALITY[i]}"
         i += 1
       end
@@ -412,22 +412,22 @@ module SrcsetTest
     def test_srcset_respects_overriding_quality
       quality_override = 100
       srcset = mock_signed_client.to_srcset(
-        w: 100, ar: '3:2', q: quality_override
+        w: 100, ar: "3:2", q: quality_override
       )
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
 
     def test_disable_variable_quality
       srcset = mock_signed_client.to_srcset(
-        w: 100, ar: '3:2',
+        w: 100, ar: "3:2",
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
-        assert(not(src.include?('q=')))
+      srcset.split(",").map do |src|
+        assert(!src.include?("q="))
       end
     end
 
@@ -438,7 +438,7 @@ module SrcsetTest
         options: { disable_variable_quality: true }
       )
 
-      srcset.split(',').map do |src|
+      srcset.split(",").map do |src|
         assert_includes src, "q=#{quality_override}"
       end
     end
@@ -446,7 +446,7 @@ module SrcsetTest
     private
 
     def srcset
-      @client ||= mock_signed_client.to_srcset({ h: 100, ar: '3:2' })
+      @client ||= mock_signed_client.to_srcset({ h: 100, ar: "3:2" })
     end
   end
 
@@ -455,7 +455,7 @@ module SrcsetTest
 
     def test_srcset_generates_width_pairs
       expected_number_of_pairs = 15
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
@@ -463,21 +463,21 @@ module SrcsetTest
                      538, 753, 1054, 1476, 2066,
                      2893, 4050, 5669, 7937, 8192]
 
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], resolutions[i])
       end
     end
 
     def test_srcset_within_bounds
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
       assert_operator min, :>=, 100
       assert_operator max, :<=, 8192
     end
@@ -487,13 +487,13 @@ module SrcsetTest
       increment_allowed = 0.41
 
       # create an array of widths
-      widths = srcset.split(',').map do |src|
-        src.split(' ')[1].to_i
+      widths = srcset.split(",").map do |src|
+        src.split(" ")[1].to_i
       end
 
       prev = widths[0]
 
-      for i in 1..widths.length - 1
+      (1..widths.length - 1).each do |i|
         element = widths[i]
         assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
         prev = element
@@ -502,7 +502,7 @@ module SrcsetTest
 
     def test_invalid_tolerance_emits_error
       assert_raises(ArgumentError) do
-        mock_client.to_srcset(options: { width_tolerance: 'abc' })
+        mock_client.to_srcset(options: { width_tolerance: "abc" })
       end
     end
 
@@ -515,21 +515,21 @@ module SrcsetTest
     def test_with_param_after
       srcset = mock_signed_client.to_srcset(
         options: { width_tolerance: 0.20 },
-        h: 1000, fit: 'clip'
+        h: 1000, fit: "clip"
       )
 
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('width_tolerance=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("width_tolerance="))
     end
 
     def test_with_param_before
       srcset = mock_signed_client.to_srcset(
-        h: 1000, fit: 'clip',
+        h: 1000, fit: "clip",
         options: { width_tolerance: 0.20 }
       )
 
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('width_tolerance=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("width_tolerance="))
     end
 
     private
@@ -546,26 +546,26 @@ module SrcsetTest
 
     def test_srcset_generates_width_pairs
       expected_number_of_pairs = 4
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
       resolutions = [100, 500, 1000, 1800]
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], resolutions[i])
       end
     end
 
     def test_srcset_within_bounds
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, @widths[0]
       assert_operator max, :<=, @widths[-1]
@@ -573,7 +573,7 @@ module SrcsetTest
 
     def test_invalid_widths_input_emits_error
       assert_raises(ArgumentError) do
-        mock_client.to_srcset(options: { widths: 'abc' })
+        mock_client.to_srcset(options: { widths: "abc" })
       end
     end
 
@@ -592,20 +592,20 @@ module SrcsetTest
     def test_with_param_after
       srcset = mock_signed_client.to_srcset(
         options: { widths: [100, 200, 300] },
-        h: 1000, fit: 'clip'
+        h: 1000, fit: "clip"
       )
 
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('widths=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("widths="))
     end
 
     def test_with_param_before
       srcset = mock_client.to_srcset(
-        h: 1000, fit: 'clip',
+        h: 1000, fit: "clip",
         options: { widths: [100, 200, 300] }
       )
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('widths=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("widths="))
     end
 
     private
@@ -621,27 +621,27 @@ module SrcsetTest
 
     def test_srcset_generates_width_pairs
       expected_number_of_pairs = 11
-      assert_equal expected_number_of_pairs, srcset.split(',').length
+      assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
       resolutions = [500, 580, 673, 780, 905, 1050,
-        1218, 1413, 1639, 1901, 2000]
-      srclist = srcset.split(',').map do |srcset_split|
-        srcset_split.split(' ')[1].to_i
+                     1218, 1413, 1639, 1901, 2000]
+      srclist = srcset.split(",").map do |srcset_split|
+        srcset_split.split(" ")[1].to_i
       end
 
-      for i in 0..srclist.length - 1
+      (0..srclist.length - 1).each do |i|
         assert_equal(srclist[i], resolutions[i])
       end
     end
 
     def test_srcset_within_bounds
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, @MIN
       assert_operator max, :<=, @MAX
@@ -656,13 +656,13 @@ module SrcsetTest
       increment_allowed = 0.41
 
       # create an array of widths
-      widths = srcset.split(',').map do |src|
-        src.split(' ')[1].to_i
+      widths = srcset.split(",").map do |src|
+        src.split(" ")[1].to_i
       end
 
       prev = widths[0]
 
-      for i in 1..widths.length - 1
+      (1..widths.length - 1).each do |i|
         element = widths[i]
         assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
         prev = element
@@ -671,7 +671,7 @@ module SrcsetTest
 
     def test_invalid_min_emits_error
       assert_raises(ArgumentError) do
-        mock_client.to_srcset(options: { min_width: 'abc' })
+        mock_client.to_srcset(options: { min_width: "abc" })
       end
     end
 
@@ -684,23 +684,23 @@ module SrcsetTest
     def test_with_param_after
       srcset = mock_client.to_srcset(
         options: { min_width: 500, max_width: 2000 },
-        h: 1000, fit: 'clip'
+        h: 1000, fit: "clip"
       )
 
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('min_width=')))
-      assert(not(srcset.include?('max_width=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("min_width="))
+      assert(!srcset.include?("max_width="))
     end
 
     def test_with_param_before
       srcset = mock_client.to_srcset(
-        h: 1000, fit: 'clip',
+        h: 1000, fit: "clip",
         options: { min_width: 500, max_width: 2000 }
       )
 
-      assert_includes(srcset, 'h=')
-      assert(not(srcset.include?('min_width=')))
-      assert(not(srcset.include?('max_width=')))
+      assert_includes(srcset, "h=")
+      assert(!srcset.include?("min_width="))
+      assert(!srcset.include?("max_width="))
     end
 
     def test_only_min
@@ -708,11 +708,11 @@ module SrcsetTest
       max_width = 8192
       srcset = mock_client.to_srcset(options: { min_width: min_width })
 
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, min_width
       assert_operator max, :<=, max_width
@@ -722,11 +722,11 @@ module SrcsetTest
       min_width = 100
       max_width = 1000
       srcset = mock_client.to_srcset(options: { max_width: max_width })
-      min, *max = srcset.split(',')
+      min, *max = srcset.split(",")
 
       # parse out the width descriptor as an integer
-      min = min.split(' ')[1].to_i
-      max = max[max.length - 1].split(' ')[1].to_i
+      min = min.split(" ")[1].to_i
+      max = max[max.length - 1].split(" ")[1].to_i
 
       assert_operator min, :>=, min_width
       assert_operator max, :<=, max_width
@@ -734,12 +734,12 @@ module SrcsetTest
 
     def test_max_as_100
       srcset = mock_client.to_srcset(options: { max_width: 100 })
-      assert_equal(srcset, 'https://testing.imgix.net/image.jpg?w=100 100w')
+      assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=100 100w")
     end
 
     def test_min_as_8192
       srcset = mock_client.to_srcset(options: { min_width: 8192 })
-      assert_equal(srcset, 'https://testing.imgix.net/image.jpg?w=8192 8192w')
+      assert_equal(srcset, "https://testing.imgix.net/image.jpg?w=8192 8192w")
     end
 
     private

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class UrlTest < Imgix::Test
-  DEMO_IMAGE_PATH = '/images/demo.png'
+  DEMO_IMAGE_PATH = "/images/demo.png"
 
   def test_signing_with_no_params
     path = client.path(DEMO_IMAGE_PATH)
 
-    assert_equal 'https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4', path.to_url
+    assert_equal "https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4", path.to_url
   end
 
   def test_signing_with_one
@@ -16,11 +16,11 @@ class UrlTest < Imgix::Test
 
     assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.width = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.width = 200
+    end
 
-    assert_equal 'https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e', path.to_url
+    assert_equal "https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e", path.to_url
   end
 
   def test_signing_with_multiple_params
@@ -28,53 +28,56 @@ class UrlTest < Imgix::Test
 
     assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.height = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.height = 200
+    end
 
     assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.width = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.width = 200
+    end
 
-    assert_equal 'https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a', path.to_url
+    assert_equal "https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a", path.to_url
 
     path = client.path(DEMO_IMAGE_PATH)
 
     assert_output(nil, "Warning: `Path.width=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.width = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.width = 200
+    end
 
     assert_output(nil, "Warning: `Path.height=' has been deprecated and " \
       "will be removed in the next major version (along " \
-      "with all parameter `ALIASES`).\n") {
-        path.height = 200
-    }
+      "with all parameter `ALIASES`).\n") do
+      path.height = 200
+    end
 
-    assert_equal 'https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379', path.to_url
+    assert_equal "https://demo.imgix.net/images/demo.png?w=200&h=200&s=00b5cde5c7b8bca8618cb911da4ac379", path.to_url
   end
 
   def test_domain_resolves_host_warn
     assert_output(nil, "Warning: The identifier `host' has been deprecated and " \
       "will\nappear as `domain' in the next major version, e.g. " \
       "`@host'\nbecomes `@domain', `options[:host]' becomes " \
-      "`options[:domain]'.\n") {
-        Imgix::Client.new(host: 'demo.imgix.net', include_library_param: false)
-    }
-
+      "`options[:domain]'.\n") do
+      Imgix::Client.new(host: "demo.imgix.net", include_library_param: false)
+    end
 
     # Assert the output of this call (to both stdout and stderr) is nil.
-    assert_output(nil, nil) {
-      Imgix::Client.new(domain: 'demo.imgix.net', include_library_param: false)
-    }
+    assert_output(nil, nil) do
+      Imgix::Client.new(domain: "demo.imgix.net", include_library_param: false)
+    end
   end
 
-private
+  private
 
   def client
-    @client ||= Imgix::Client.new(host: 'demo.imgix.net', secure_url_token: '10adc394', include_library_param: false)
+    @client ||= Imgix::Client.new(
+      host: "demo.imgix.net",
+      secure_url_token: "10adc394",
+      include_library_param: false
+    )
   end
 end


### PR DESCRIPTION
This PR represents a medium-sized-step towards automating consistency.
There are two commit: the first is largely concerned with enforcing the use
of double quoted strings (over single quoted strings).

Prior to this PR there were quite a few "offenses detected." Now, we must
only deal with ~102 offenses (many of which are minor and/or will be removed
in the next MAJOR).

I went through file by file and ran the rubocop formatter selectively. As such,
there were a few (1-3) changes made that are unrelated to double quotation.
A few `{ }` blocks were replaced with `do end` as they spanned multiple lines.

A couple more changes (1-3) removed a couple for-blocks:
```ruby
for i in 0..srclist.length - 1 do
  assert_equal(srclist[i], resolutions[I])
end
```

In favor of `.each` blocks:
```ruby
(0..srclist.length - 1).each do |i|
  assert_equal(srclist[i], resolutions[i])
end
```

To which I say, "ohmmmkay rubocop."
