### PR TITLE
feat: Allow domain to have a port

### DIFF
--- a/lib/imgix.rb
+++ b/lib/imgix.rb
@@ -6,7 +6,7 @@ require "imgix/path"
 
 module Imgix
   # regex pattern used to determine if a domain is valid
-  DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}$/i.freeze
+  DOMAIN_REGEX = /^(?:[a-z\d\-_]{1,62}\.){0,125}(?:[a-z\d](?:\-(?=\-*[a-z\d])|[a-z]|\d){0,62}\.)[a-z\d]{1,63}(:\d+)?$/i.freeze
 
   # determines the growth rate when building out srcset pair widths
   DEFAULT_WIDTH_TOLERANCE = 0.08

--- a/test/units/domains_test.rb
+++ b/test/units/domains_test.rb
@@ -3,6 +3,10 @@
 require 'test_helper'
 
 class DomainsTest < Imgix::Test
+  def test_valid_port_on_domain
+    Imgix::Client.new(domain: "localhost.me:3000")
+  end
+
   def test_invalid_domain_append_slash
     assert_raises(ArgumentError) {Imgix::Client.new(domain: "assets.imgix.net/")}
   end


### PR DESCRIPTION
This allows us to use imgix lib without much changes on local
environment. We can then have the source be something like
"localhost.me:3000" and it just works, pointing to the right asset but
without any transformations.

Without this, devs who can't use S3 on the local environment have to
resort to hacks on their code to workaround this small regex test, which
is not ideal.


## Checklist: New Feature

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.
- [x] Any breaking changes are specified on the commit on which they are introduced with `BREAKING CHANGE` in the body of the commit.
- [x] If this is a big feature with breaking changes, consider [opening an issue](https://github.com/imgix/imgix-rb/issues/new?labels=&template=feature_request.md&title=) to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!

## Steps to Test


Setting source/domain to something like `localhost.me:3000` should now work.