### PR TITLE
docs: fixed typo w/ srcset min/max widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,11 +144,11 @@ https://testing.imgix.net/image.jpg?w=8192 8192w
 
 ### Minimum and Maximum Width Ranges
 
-If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer via `min_srcset` and/or `max_srcset` to the `options` keyword parameters:
+If the exact number of minimum/maximum physical pixels that an image will need to be rendered at is known, a user can specify them by passing an integer via `min_width` and/or `max_width` to the `options` keyword parameters:
 
 ```rb
 client = Imgix::Client.new(domain: 'testing.imgix.net', include_library_param: false)
-client.path('image.jpg').to_srcset(options: { min_srcset: 500, max_srcset: 2000 })
+client.path('image.jpg').to_srcset(options: { min_width: 500, max_width: 2000 })
 ```
 
 Will result in a smaller, more tailored srcset.
@@ -167,7 +167,7 @@ https://testing.imgix.net/image.jpg?w=1902 1902w,
 https://testing.imgix.net/image.jpg?w=2000 2000w
 ```
 
-Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_srcset: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
+Remember that browsers will apply a device pixel ratio as a multiplier when selecting which image to download from a `srcset`. For example, even if you know your image will render no larger than 1000px, specifying `options: { max_width: 1000 }` will give your users with DPR higher than 1 no choice but to download and render a low-resolution version of the image. Therefore, it is vital to factor in any potential differences when choosing a minimum or maximum range.
 
 Also please note that according to the [imgix API](https://docs.imgix.com/apis/url/size/w), the maximum renderable image width is 8192 pixels.
 


### PR DESCRIPTION
<!--
Hello, and thanks for contributing to imgix-rb! 🎉🙌
Please take a second to fill out PRs with the following template!
-->

# Description

<!-- What is accomplished by this PR? If there is something potentially controversial in your PR, please take a moment to tell us about your choices. -->

This PR fixes a couple issues in the docs with `min_width` and `max_width` not being documented correctly. I had to dig through the source code to figure out why things were not working as expected. Hopefully this saves some others some time.

<!-- 
Please use the checklist that is most closely related to your PR, and delete the other checklists. -->

## Checklist: Fixing typos/Doc change

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.

<!-- A link to a codepen/codesandbox is also an option. -->

<!--

## Conventional Commit Spec

PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`

`type` can be any of the follow:
  - `feat`: a feature, or breaking change
  - `fix`: a bug-fix
  - `test`: Adding missing tests or correcting existing tests
  - `docs`: documentation only changes (readme, changelog, contributing guide)
  - `refactor`: a code change that neither fixes a bug nor adds a feature
  - `chore`: reoccurring tasks for project maintainability (example scopes: release, deps)
  - `config`: changes to tooling configurations used in the project
  - `build`: changes that affect the build system or external dependencies (example scopes: npm, bundler, gradle)
  - `ci`: changes to CI configuration files and scripts (example scopes: travis)
  - `perf`: a code change that improves performance
  - `style`: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

`scope` is optional, and can be anything.
`description` should be a short description of the change, written in the imperative-mood.
-->
