### PR TITLE
fix:  dpr srcset when only h param

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ https://your-subdomain.imgix.net/images/demo.png?w=8192&s=9fbd257c53e770e345ce34
 
 ### Fixed image rendering
 
-In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w`, `h`, and `ar`. By invoking `to_srcset` with either a width **or** the height and aspect ratio (along with `fit=crop`, typically) provided, a different `srcset` will be generated for a fixed-size image instead.
+In cases where enough information is provided about an image's dimensions, `to_srcset` will instead build a `srcset` that will allow for an image to be served at different resolutions. The parameters taken into consideration when determining if an image is fixed-width are `w` or `h`. By invoking `to_srcset` with either a width **or** height provided, a different `srcset` will be generated for a fixed-size image instead.
 
 ```rb
 client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', secure_url_token: 'your-token', include_library_param: false)

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -53,7 +53,7 @@ module Imgix
       height = @options[:h]
       aspect_ratio = @options[:ar]
 
-      srcset = if width || (height && aspect_ratio)
+      srcset = if width || height
           build_dpr_srcset(options: options, params: @options)
         else
           build_srcset_pairs(options: options, params: @options)

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -192,17 +192,6 @@ module SrcsetTest
       end
     end
 
-    def test_srcset_within_bounds
-      min, *max = srcset.split(",")
-
-      # parse out the width descriptor as an integer
-      min = min.split(" ")[1].to_i
-      max = max[max.length - 1].split(" ")[1].to_i
-
-      assert_operator min, :>=, 100
-      assert_operator max, :<=, 8192
-    end
-
     # a 17% testing threshold is used to account for rounding
     def test_srcset_iterates_17_percent
       increment_allowed = 0.17

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -11,7 +11,6 @@ module SrcsetTest
   ].freeze
 
   DPR_QUALITY = [75, 50, 35, 23, 20].freeze
-  DPR_MULTIPLIER = ["1x", "2x", "3x", "4x", "5x", ].freeze
 
   DOMAIN = "testing.imgix.net"
   TOKEN = "MYT0KEN"

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -172,7 +172,7 @@ module SrcsetTest
     def test_srcset_pair_values
       resolutions = DPR_MULTIPLIER
       srclist = srcset.split(",").map do |srcset_split|
-        srcset_split.split(" ")[1].to_i
+        srcset_split.split(" ")[1]
       end
 
       (0..srclist.length - 1).each do |i|

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -192,24 +192,6 @@ module SrcsetTest
       end
     end
 
-    # a 17% testing threshold is used to account for rounding
-    def test_srcset_iterates_17_percent
-      increment_allowed = 0.17
-
-      # create an array of widths
-      widths = srcset.split(",").map do |src|
-        src.split(" ")[1].to_i
-      end
-
-      prev = widths[0]
-
-      (1..widths.length - 1).each do |i|
-        element = widths[i]
-        assert_operator (element.to_f / prev.to_f), :<, (1 + increment_allowed)
-        prev = element
-      end
-    end
-
     def test_srcset_signs_urls
       srcset.split(",").map do |srcset_split|
         src = srcset_split.split(" ")[0]

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -11,6 +11,7 @@ module SrcsetTest
   ].freeze
 
   DPR_QUALITY = [75, 50, 35, 23, 20].freeze
+  DPR_MULTIPLIER = ["1x", "2x", "3x", "4x", "5x", ].freeze
 
   DOMAIN = "testing.imgix.net"
   TOKEN = "MYT0KEN"
@@ -164,18 +165,18 @@ module SrcsetTest
     include SrcsetTest
 
     def test_srcset_generates_width_pairs
-      expected_number_of_pairs = 31
+      expected_number_of_pairs = 5
       assert_equal expected_number_of_pairs, srcset.split(",").length
     end
 
     def test_srcset_pair_values
-      resolutions = RESOLUTIONS
+      resolutions = DPR_MULTIPLIER
       srclist = srcset.split(",").map do |srcset_split|
         srcset_split.split(" ")[1].to_i
       end
 
       (0..srclist.length - 1).each do |i|
-        assert_equal(srclist[i], resolutions[i])
+        assert_equal(resolutions[i], srclist[i])
       end
     end
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -186,6 +186,12 @@ module SrcsetTest
       end
     end
 
+    def test_srcset_includes_dpr_param
+      srcset.split(",").map do |src|
+        assert_includes src, "dpr="
+      end
+    end
+
     def test_srcset_within_bounds
       min, *max = srcset.split(",")
 

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -446,7 +446,7 @@ module SrcsetTest
     private
 
     def srcset
-      @client ||= mock_signed_client.to_srcset({ h: 100, ar: "3:2" })
+      @client ||= mock_signed_client.to_srcset(h: 100, ar: "3:2")
     end
   end
 


### PR DESCRIPTION
# Description

This PR ensures a DPR-based SrcSet is generated when a fixed height is the only parameter value.

It removes tests that no longer apply to only having `h` as a param, and
adds tests that ensure the DPR sercset was generated correctly.