### PR TITLE
ci: remove support for ruby version <2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ bundler_args: --without development
 rvm:
   - 2.7.0
   - 2.6.3
-  - 2.3.0
-  - 2.2.4
-  - 2.1.8
   - jruby-9.2.11.0
 
 jobs:
@@ -20,4 +17,3 @@ jobs:
   
   allow_failures:
     - name: Rubinius
- 


### PR DESCRIPTION
Starting today (March 31, 2021) Ruby version 2.5 is [EOL](https://www.ruby-lang.org/en/downloads/branches/) and as such, no longer needs to be supported.