### PR TITLE
ci: use optimistic versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
 
   include:
     - name: Rubinius
-      rvm: rbx-3.107
+      rvm: rbx-3
       dist: trusty
   
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ dist: trusty
 language: ruby
 bundler_args: --without development
 rvm:
-  - 2.7.0
-  - 2.6.3
+  - 2.7
+  - 2.6
   - jruby-9.2.11.0
 
 jobs:


### PR DESCRIPTION
This PR changes the Ruby versions tested by Travis to use optimistic versioning.

I tried to add a build for Ruby 3.0 but there is an issue where Travis does not import the proper GPG keys for RVM prior to attempting to install Ruby. (Explored in https://github.com/rvm/rvm/issues/4561)
I suggest waiting until this issue is resolved before adding a test for Ruby version 3.0 and later.