### PR TITLE
fix(path): correctly encode delimiters and relative paths

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,10 @@
 		{
 			"label": "rake: test",
 			"type": "shell",
-			"group": "test",
+			"group":{
+				"kind": "test",
+				"isDefault": true
+			},
 			"problemMatcher": {
 				"owner": "ruby",
 				"fileLocation": ["relative", "${workspaceFolder}"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,26 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "rake: test",
+			"type": "shell",
+			"group": "test",
+			"problemMatcher": {
+				"owner": "ruby",
+				"fileLocation": ["relative", "${workspaceFolder}"],
+				"pattern": [
+						{
+							"regexp": "^([^:]+: .+)",
+							"message": 1
+						},
+						{
+							"regexp": "^    ([^:]+):(\\d+)",
+							"file": 1,
+							"line": 2
+						}
+				]
+			},
+			"command": "bundle exec rake test"
+		}
+	]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,7 @@ gemspec
 gem 'rake'
 gem 'json'
 gem 'minitest'
+gem 'minitest-reporters'
 gem 'webmock'
 gem 'benchmark-ips'
+

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -10,7 +10,6 @@ module Imgix
     def initialize(prefix, secure_url_token, path = "/")
       @prefix = prefix
       @secure_url_token = secure_url_token
-      #TODO(luqven): should this method not be invoked on initialization?
       @path = path
       @options = {}
     end

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -15,7 +15,7 @@ module Imgix
     end
 
     def to_url(opts = {})
-      sanitized_path ||= sanitize_path(@path)
+      sanitized_path = sanitize_path(@path)
       prev_options = @options.dup
       @options.merge!(opts)
 

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -15,11 +15,11 @@ module Imgix
     end
 
     def to_url(opts = {})
-      @path = sanitize_path(@path)
+      sanitized_path ||= sanitize_path(@path)
       prev_options = @options.dup
       @options.merge!(opts)
 
-      current_path_and_params = path_and_params
+      current_path_and_params = path_and_params(sanitized_path)
       url = @prefix + current_path_and_params
 
       if @secure_url_token
@@ -161,12 +161,12 @@ module Imgix
       return result;
     end
 
-    def signature(path_and_params)
-      Digest::MD5.hexdigest(@secure_url_token + path_and_params)
+    def signature(rest)
+      Digest::MD5.hexdigest(@secure_url_token + rest)
     end
 
-    def path_and_params
-      has_query? ? "#{@path}?#{query}" : @path
+    def path_and_params(path)
+      has_query? ? "#{path}?#{query}" : path
     end
 
     def query

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -42,32 +42,10 @@ module Imgix
       result = []
       path.split("/").each do |str|
         escaped_key = ERB::Util.url_encode(str)
-        escaped_key = utf8_encode_delimiter(escaped_key)
         result << escaped_key
       end
       result =  "/" + result.join("/")
       return result;
-    end
-
-    def utf8_encode_delimiter(char)
-      encoding  = { 
-        " ": "%20",
-        "<": "%3C",
-        ">": "%3E",
-        "[": "%5B",
-        "]": "%5D",
-        "{": "%7B",
-        "}": "%7D",
-        "|": "%7C",
-        "\\": "%5C",
-        "^": "%5E",
-        "%": "%25"
-      }
-      if encoding[char]
-        return encoding[char]
-      else
-        return char
-      end
     end
 
     def to_url(opts = {})

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -152,13 +152,14 @@ module Imgix
     # URL encode every character in the path, including
     # " +?:#" characters.
     def encode_URI(path)
-      result = []
+      # For each component in the path, URL encode it and add it
+      # to the array path component.
+      path_components = []
       path.split("/").each do |str|
-        escaped_key = ERB::Util.url_encode(str)
-        result << escaped_key
+        path_components << ERB::Util.url_encode(str)
       end
-      result =  "/" + result.join("/")
-      return result;
+      # Prefix and join the encoded path components.
+      "/#{path_components.join('/')}"
     end
 
     def signature(rest)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,5 +8,10 @@ require "minitest/autorun"
 require "imgix"
 require "webmock/minitest"
 
+require 'minitest/autorun'
+require 'minitest/reporters' # requires the gem
+
+Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
+
 class Imgix::Test < MiniTest::Test
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,9 +7,7 @@ Bundler.require :test
 require "minitest/autorun"
 require "imgix"
 require "webmock/minitest"
-
-require 'minitest/autorun'
-require 'minitest/reporters' # requires the gem
+require "minitest/reporters"
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -85,6 +85,11 @@ class PathTest < Imgix::Test
     assert_equal "https://demo.imgix.net/demo.png?hello_world=%2Ffoo%22%3E%20%3Cscript%3Ealert%28%22hacked%22%29%3C%2Fscript%3E%3C", ix_url
   end
 
+  def test_unicode_path_variants_are_utf8_encoded
+    ix_url = unsigned_client.path("I cannøt belîév∑ it wors! 😱").to_url
+
+    assert_equal "https://demo.imgix.net/I%20cann%C3%B8t%20bel%C3%AE%C3%A9v%E2%88%91%20it%20wor%EF%A3%BFs%21%20%F0%9F%98%B1", ix_url
+  end
   def test_base64_param_variants_are_base64_encoded
     ix_url = unsigned_client.path("~text").to_url({txt64: "I cannøt belîév∑ it wors! 😱"})
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -61,9 +61,25 @@ class PathTest < Imgix::Test
   end
 
   def test_file_path_with_reserved_delimiters
-    url = "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg?h=200&w=200&s=1731846fd046c84270d052b1152b0cfa"
-    path = client.path("/ <>[]{}|\\^%.jpg").h(200).w(200)
-    assert_equal url, path.to_url
+    urls = [
+      "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg?h=200&w=200&s=1731846fd046c84270d052b1152b0cfa",
+      "https://demo.imgix.net/%26%24%2B%2C%3A%3B%3D%3F%40%23.jpg?h=200&w=200&s=08730633f350ceb3cc6bce4caa4be55a",
+    ]
+    paths = [
+      "/ <>[]{}|\\^%.jpg",
+      "&$+,:;=?@#.jpg",
+    ]
+    result = true
+    message = "URLS Encoded Incorrectly: "
+
+    urls.each_with_index do |url, idx|
+      current_url = client.path(paths[idx]).h(200).w(200).to_url
+      if (url != current_url)
+        message += "\n #{current_url} != \n #{url}"
+        result = false
+      end
+    end
+    assert(result, message)
   end
 
   def test_path_with_multi_value_param_safely_encoded
@@ -86,10 +102,25 @@ class PathTest < Imgix::Test
   end
 
   def test_unicode_path_variants_are_utf8_encoded
-    ix_url = unsigned_client.path("I cannøt belîév∑ it wors! 😱").to_url
+    urls = [
+      "https://demo.imgix.net/I%20cann%C3%B8t%20bel%C3%AE%C3%A9v%E2%88%91%20it%20wor%EF%A3%BFs%21%20%F0%9F%98%B1",
+      "https://demo.imgix.net/%D8%B3%D8%A7%D9%86%D8%AF%D9%88%DB%8C%DA%86.jpg"
+    ]
+    paths = [ "I cannøt belîév∑ it wors! 😱", "ساندویچ.jpg"]
+    result = true
+    message = "URLs Encoded Incorrectly: "
 
-    assert_equal "https://demo.imgix.net/I%20cann%C3%B8t%20bel%C3%AE%C3%A9v%E2%88%91%20it%20wor%EF%A3%BFs%21%20%F0%9F%98%B1", ix_url
+    urls.each_with_index do |url, idx|
+      current_url = unsigned_client.path(paths[idx]).to_url
+      if (url != current_url)
+        result = false
+        message += "\n #{current_url} != \n #{url}"
+      end
+    end
+
+    assert(result, message)
   end
+
   def test_base64_param_variants_are_base64_encoded
     ix_url = unsigned_client.path("~text").to_url({txt64: "I cannøt belîév∑ it wors! 😱"})
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -61,8 +61,8 @@ class PathTest < Imgix::Test
   end
 
   def test_file_path_with_reserved_delimiters
-    url = "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5C%5E%25.jpg?h=200&w=200&s=c53e7dc75b2d8fb70006f12357881622"
-    path = client.path("/ <>[]{}|\\\\^%.jpg").h(200).w(200)
+    url = "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg?h=200&w=200&s=1731846fd046c84270d052b1152b0cfa"
+    path = client.path("/ <>[]{}|\\^%.jpg").h(200).w(200)
     assert_equal url, path.to_url
   end
 

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -54,6 +54,18 @@ class PathTest < Imgix::Test
     assert_equal url, path.to_url
   end
 
+  def test_relative_path_with_params
+    url = "https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a"
+    path = client.path("images/demo.png").h(200).w(200)
+    assert_equal url, path.to_url
+  end
+
+  def test_file_path_with_reserved_delimiters
+    url = "https://demo.imgix.net/%20%3C%3E%5B%5D%7B%7D%7C%5C%5C%5E%25.jpg?h=200&w=200&s=c53e7dc75b2d8fb70006f12357881622"
+    path = client.path("/ <>[]{}|\\\\^%.jpg").h(200).w(200)
+    assert_equal url, path.to_url
+  end
+
   def test_path_with_multi_value_param_safely_encoded
     url = "https://demo.imgix.net/images/demo.png?markalign=middle%2Ccenter&s=f0d0e28a739f022638f4ba6dddf9b694"
     path = client.path("/images/demo.png").markalign("middle,center")

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -26,6 +26,22 @@ class UrlTest < Imgix::Test
     assert_equal expected, path.to_url(h: 200, w: 200)
   end
 
+  def test_calling_to_url_many_times
+    path = client.path(DEMO_IMAGE_PATH)
+    expected = ["https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a"]
+    result = []
+
+    10.times do
+      expected << expected[0]
+    end
+
+    expected.length.times do
+      result << path.to_url(h: 200, w: 200)
+    end
+
+    assert_equal expected, result
+  end
+
   private
 
   def client


### PR DESCRIPTION
> Do not merge until rebased on #103 and #104 

# Description

This PR adds a `sanitize_path` method to `path.rb`, related tests, and build improvements.

### Tests
Using `gem 'minitest-reporters'`, `miniTest` output logs now behave similarly to rSpec's, with color formatting and better diffing. 

Test suite logging example:
``` console
SrcsetTest::SrcsetMinMaxWidths
  test_srcset_generates_width_pairs                               PASS (0.00s)
  test_only_max                                                   PASS (0.00s)
  test_srcset_pair_values                                         PASS (0.00s)
  test_negative_max_emits_error                                   PASS (0.00s)
...

Finished in 0.03846s
91 tests, 620 assertions, 0 failures, 0 errors, 0 skips
```
Diffing example:
``` console
test_resetting_defaults                                         FAIL (0.00s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -"https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e"
        +"https://demo.imgix.netfalse?w=200&s=59a2133b87f1b07792f54601d0988c77"
        /Users/Luis/Documents/imgix/libraries/imgix-rb/test/units/path_test.rb:23:in `test_resetting_defaults'
```

Tests can also be run in VSCode as the default test task, `SHIFT + COMMAND + T` in  my system for example.

### Up for discussion

One of the ways this code base could be improved would be to re-name a lot of the methods. This library exposes a `to_url` method instead of a `build_url` method like some of the others for example. Moreover, the logic for path encoding is separate from the rest of the library, but that's not how the projects are organized elsewhere.