### PR TITLE
chore: rebase "Optimise Imgix::Path#to_url by not generating the escaped query string twice"

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -21,10 +21,11 @@ module Imgix
       prev_options = @options.dup
       @options.merge!(opts)
 
-      url = @prefix + path_and_params
+      current_path_and_params = path_and_params
+      url = @prefix + current_path_and_params
 
       if @secure_url_token
-        url += (has_query? ? "&" : "?") + "s=#{signature}"
+        url += (has_query? ? "&" : "?") + "s=#{signature(current_path_and_params)}"
       end
 
       @options = prev_options
@@ -129,8 +130,8 @@ module Imgix
 
     private
 
-    def signature
-      Digest::MD5.hexdigest(@secure_url_token + path_and_params)
+    def signature(current_path_and_params)
+      Digest::MD5.hexdigest(@secure_url_token + current_path_and_params)
     end
 
     def path_and_params

--- a/script/bench_to_url.rb
+++ b/script/bench_to_url.rb
@@ -1,0 +1,12 @@
+$LOAD_PATH << 'lib'
+require 'imgix'
+require 'benchmark/ips'
+
+client = Imgix::Client.new(domain: 'domain.com', secure_url_token: 'token')
+path = client.path("/img.jpg")
+
+Benchmark.ips do |x|
+  x.report('Imgix::Path#to_url') do
+    path.to_url({ auto: 'compress,format', fit: 'crop', crop: 'top', w: 590, h: 332 })
+  end
+end


### PR DESCRIPTION
Opened as a follow up to #103 