### PR TITLE
fix: encode web proxy paths using url_encode

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -146,7 +146,7 @@ module Imgix
 
     # URL encode the entire path
     def encode_URI_Component(path)
-      return "/" + CGI.escape(path)
+      return "/" + ERB::Util.url_encode(path)
     end
 
     # URL encode every character in the path, including

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -155,7 +155,7 @@ class PathTest < Imgix::Test
 
   def test_full_url_with_a_space
     path = "https://my-demo-site.com/files/133467012/avatar icon.png"
-    assert_equal "https://demo.imgix.net/#{CGI.escape(path)}?s=35ca40e2e7b6bd208be2c4f7073f658e", client.path(path).to_url
+    assert_equal "https://demo.imgix.net/https%3A%2F%2Fmy-demo-site.com%2Ffiles%2F133467012%2Favatar%20icon.png?s=0698b87ab279364977e93f0e6baee41b", client.path(path).to_url
   end
 
   def test_include_library_param


### PR DESCRIPTION
This PR changes the encoding function used on web proxy paths from `CGI.escape` to `ERB::Util.url_encode`, which is the same function used for general path encoding in this library. Because this library uses `CGI.escape` to encode a web proxy path, it encodes spaces as `+` rather than `%20` (due to following the [CGI/HTML form spec](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1)). However, encoding in this way results in URLs that do not resolve properly. More details can be found in this [SO discussion](https://stackoverflow.com/a/28574383/10366522).

See test below with active source:

```rb
client = Imgix::Client.new(domain: "sherwinski-proxy.imgix.net", include_library_param: false, secure_url_token: ...)
path = "https://sherwinski.imgix.net/ <>[]{}|\\^%.jpg"
puts client.path(path).to_url
```

```
// main branch - 403 Forbidden
https://sherwinski-proxy.imgix.net/https%3A%2F%2Fsherwinski.imgix.net%2F+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg?s=35ca40e2e7b6bd208be2c4f7073f658e

// this branch - 200 OK
https://sherwinski-proxy.imgix.net/https%3A%2F%2Fsherwinski.imgix.net%2F%20%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg?s=2c215192a0fb2ee4c075cb7f6b57ea59
```