### PR TITLE
chore: exclude .vscode directory from distributed gem

### DIFF
--- a/imgix.gemspec
+++ b/imgix.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|.github)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features|.github|.vscode)/}) }
   end
 
   spec.require_paths = ["lib"]


### PR DESCRIPTION
We can choose the files/dirs that end up in our distributed gem
(i.e. the gem users download). E.g. when doing a bundle install
the user just wants the gem and they'll get the lean contents of
the gem. Conversely, if someone wants to contribute they'll clone
the repo and get everything (i.e. tests, dot folders, etc.)
