### PR TITLE
feat: add parameter to disable path encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ client.path('/[images]/demo.png').to_url
 #=> https://your-subdomain.imgix.net/%5Bimages%5D/demo.png?s=270832685733a36ba02bd8ab9fd72df5
 client.path('/[images]/demo.png').to_url({},{disable_path_encoding: true})
 #=> https://your-subdomain.imgix.net/[images]/demo.png?s=ed6eb07e9eff3f6c8bbcc83fc4f63198
-
+```
 ## Srcset Generation
 
 The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ client.path('/images/demo.png').to_url(w: 200)
 #=> https://your-subdomain.imgix.net/images/demo.png?w=200&s=2eadddacaa9bba4b88900d245f03f51e
 ```
 
+To disable path encoding, pass `{disable_path_encoding: true}` as the second argument to the `Imgix#Path#to_url` function.
+
+```rb
+client = Imgix::Client.new(domain: 'your-subdomain.imgix.net', secure_url_token: 'your-token')
+client.path('/[images]/demo.png').to_url
+#=> https://your-subdomain.imgix.net/%5Bimages%5D/demo.png?s=270832685733a36ba02bd8ab9fd72df5
+client.path('/[images]/demo.png').to_url({},{disable_path_encoding: true})
+#=> https://your-subdomain.imgix.net/[images]/demo.png?s=ed6eb07e9eff3f6c8bbcc83fc4f63198
+
 ## Srcset Generation
 
 The imgix gem allows for generation of custom `srcset` attributes, which can be invoked through `Imgix::Path#to_srcset`. By default, the `srcset` generated will allow for responsive size switching by building a list of image-width mappings.

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -135,16 +135,15 @@ module Imgix
     def sanitize_path(path, options = {})
       # remove the leading "/", we'll add it back after encoding
       path = path.slice(1, path.length) if Regexp.new('^/') =~ path
-      if !options[:disable_path_encoding]
-        # if path is being used as a proxy, encode the entire thing
-        if /^https?/ =~ path
-          return encode_URI_Component(path)
-        else
-          # otherwise, encode only specific characters
-          return encode_URI(path)
-        end
+      if options[:disable_path_encoding]
+        return "/" + path
+      # if path is being used as a proxy, encode the entire thing
+      elsif /^https?/ =~ path
+        return encode_URI_Component(path)
+      else
+        # otherwise, encode only specific characters
+        return encode_URI(path)
       end
-      return "/" + path
     end
 
     # URL encode the entire path

--- a/test/units/path_test.rb
+++ b/test/units/path_test.rb
@@ -11,6 +11,12 @@ class PathTest < Imgix::Test
     assert_equal "https://demo.imgix.net/images/demo.png?s=2c7c157eaf23b06a0deb2f60b81938c4", path.to_url
   end
 
+  def test_disable_path_encoding
+    path = client.path("[images]/demo.png")
+    assert_equal "https://demo.imgix.net/%5Bimages%5D/demo.png?s=270832685733a36ba02bd8ab9fd72df5", path.to_url
+    assert_equal "https://demo.imgix.net/[images]/demo.png?s=ed6eb07e9eff3f6c8bbcc83fc4f63198", path.to_url({},{disable_path_encoding: true})
+  end
+
   def test_signing_path_with_param
     url = "https://demo.imgix.net/images/demo.png?w=200&s=da421114ca238d1f4a927b889f67c34e"
     path = client.path("/images/demo.png").w(200)

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -760,4 +760,29 @@ module SrcsetTest
       )
     end
   end
+
+  class SrcsetDisablePathEncoding < Imgix::Test
+    include SrcsetTest
+
+    def test_enable_path_encoding
+      srcset = mock_client.to_srcset
+      src = srcset.split(" ")[0]
+      assert_equal(src, "https://testing.imgix.net/%5Bimage%5D.jpg?w=100")
+    end
+
+    def test_disable_path_encoding
+      srcset = mock_client.to_srcset(options: { disable_path_encoding: true })
+      src = srcset.split(" ")[0]
+      assert_equal(src, "https://testing.imgix.net/[image].jpg?w=100")
+    end
+
+    private
+
+    def mock_client
+      Imgix::Client.new(
+        domain: DOMAIN,
+        include_library_param: false
+      ).path("[image].jpg")
+    end
+  end
 end

--- a/test/units/srcset_test.rb
+++ b/test/units/srcset_test.rb
@@ -764,7 +764,7 @@ module SrcsetTest
   class SrcsetDisablePathEncoding < Imgix::Test
     include SrcsetTest
 
-    def test_enable_path_encoding
+    def test_encode_path_by_default
       srcset = mock_client.to_srcset
       src = srcset.split(" ")[0]
       assert_equal(src, "https://testing.imgix.net/%5Bimage%5D.jpg?w=100")


### PR DESCRIPTION
## Description
Adds a `disable_path_encoding` parameter to allow user to opt-out of path encoding (issue: https://github.com/imgix/imgix-rb/issues/117)

## Checklist

- [x] Read the [contributing guidelines](CONTRIBUTING.md).
- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [x] Update the readme (if applicable).
- [x] Update or add any necessary API documentation (if applicable)
- [x] All existing unit tests are still passing (if applicable).
- [x] Add new passing unit tests to cover the code introduced by your PR (if applicable).
