### PR TITLE
Ticket 62119: Fixes invalid url output

### DIFF
--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -20,6 +20,8 @@ module Imgix
       @options.merge!(params)
 
       current_path_and_params = path_and_params(sanitized_path)
+      current_path_and_params.gsub!(/=&/, "&") # Removes instances of `param=&`
+      current_path_and_params.gsub!(/=$/, "")  # Removes `=` at the end of the string
       url = @prefix + current_path_and_params
 
       if @secure_url_token

--- a/lib/imgix/path.rb
+++ b/lib/imgix/path.rb
@@ -20,8 +20,6 @@ module Imgix
       @options.merge!(params)
 
       current_path_and_params = path_and_params(sanitized_path)
-      current_path_and_params.gsub!(/=&/, "&") # Removes instances of `param=&`
-      current_path_and_params.gsub!(/=$/, "")  # Removes `=` at the end of the string
       url = @prefix + current_path_and_params
 
       if @secure_url_token
@@ -178,7 +176,9 @@ module Imgix
       @options.map do |key, val|
         escaped_key = ERB::Util.url_encode(key.to_s)
 
-        if escaped_key.end_with? '64'
+        if val.to_s.empty?
+          escaped_key
+        elsif escaped_key.end_with? '64'
           escaped_key << "=" << Base64.urlsafe_encode64(val.to_s).delete('=')
         else
           escaped_key << "=" << ERB::Util.url_encode(val.to_s)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,5 +11,5 @@ require "minitest/reporters"
 
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 
-class Imgix::Test < MiniTest::Test
+class Imgix::Test < Minitest::Test
 end

--- a/test/units/url_test.rb
+++ b/test/units/url_test.rb
@@ -26,6 +26,20 @@ class UrlTest < Imgix::Test
     assert_equal expected, path.to_url(h: 200, w: 200)
   end
 
+  def test_signing_with_nil_param
+    path = client.path(DEMO_IMAGE_PATH)
+    expected = "https://demo.imgix.net/images/demo.png?mark&s=6ca2720a15de7ec9862650cca69ad96d"
+
+    assert_equal expected, path.to_url(mark: "")
+  end
+
+  def test_signing_with_multiple_params_and_nil_param
+    path = client.path(DEMO_IMAGE_PATH)
+    expected = "https://demo.imgix.net/images/demo.png?mark&h=200&w=200&s=70e6fd73fad79125c3596c0575a6e4cf"
+
+    assert_equal expected, path.to_url(mark: "", h: 200, w: 200)
+  end
+
   def test_calling_to_url_many_times
     path = client.path(DEMO_IMAGE_PATH)
     expected = ["https://demo.imgix.net/images/demo.png?h=200&w=200&s=d570a1ecd765470f7b34a69b56718a7a"]


### PR DESCRIPTION
## Description

When making a URL with a blank parameter, it would outpoint an unneeded =

Before this PR...
https://demo.imgix.net/images/demo.png?mark=&h=200&w=200&s=XXXXXXXXXXXXXX
https://demo.imgix.net/images/demo.png?mark=

After this PR...
https://demo.imgix.net/images/demo.png?mark&h=200&w=200&s=XXXXXXXXXXXXXX
https://demo.imgix.net/images/demo.png?mark

## Checklist
- [X] Read the [contributing guidelines](CONTRIBUTING.md).
- [X] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec format.
- [X] All existing unit tests are still passing.
- [X] Add new passing unit tests to cover the code introduced by your PR.

We have a default mark parameter defined within our Imgix source settings, and we need to generate an image for use with an OG tag WITHOUT the mark parameter. We deliberately pass in a blank "mark" parameter to override the default mark parameter defined in Imgix. Sending in a blank mark parameter removes the default watermark.

The SDK generates a URL with "mark=" with the correct signature, and this image is accessible; however, when Facebook tries to download this image, it goes to the image URL with "mark" (notice without the = sign). This makes the image URL invalid because the signature is for "mark=" and not "mark," and no image loads.

When somebody shares a link to their website, the card Facebook produces has no image.

This PR solves this problem as the generated URL is missing the "=" and Facebook visits the url correctly.


PS: This commit also fixes the tests not running due to the change in Minitest, MiniTest -> Minitest